### PR TITLE
Update Travis-ci links with new repo name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xC [![Build Status](https://travis-ci.org/exercism/xc.svg?branch=master)](https://travis-ci.org/exercism/xc)
+# C [![Build Status](https://travis-ci.org/exercism/c.svg?branch=master)](https://travis-ci.org/exercism/c)
 
 Exercism problems in C
 


### PR DESCRIPTION
The repo rename #148 broke the travis-ci links, this just points the README to the correct places in Travis.