### PR TITLE
Rename references to the problem-specifications repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Exercism problems in C
 
 ## Contributing Guide
 
-Please see the [Exercism contributing guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md) for general contribution tips.
+Please see the [Exercism contributing guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md) for general contribution tips.
 
 ## Coding Style
 


### PR DESCRIPTION
We renamed x-common to problem-specifications a while back. The old links redirect, but it seems cleaner to replace them with the new links.