### PR TITLE
deleted duplicate test runs in raindrops

### DIFF
--- a/exercises/raindrops/test/test_raindrops.c
+++ b/exercises/raindrops/test/test_raindrops.c
@@ -140,22 +140,6 @@ int main(void)
    RUN_TEST(test_fifty_two_yields_itself);
    RUN_TEST(test_one_hundred_five_yields_plingplangplong);
    RUN_TEST(test_big_prime_yields_itself);
-   RUN_TEST(test_one_yields_itself);
-   RUN_TEST(test_three_yields_pling);
-   RUN_TEST(test_five_yields_plang);
-   RUN_TEST(test_seven_yields_plong);
-   RUN_TEST(test_six_yields_pling);
-   RUN_TEST(test_nine_yields_pling);
-   RUN_TEST(test_ten_yields_plang);
-   RUN_TEST(test_fourteen_yields_plong);
-   RUN_TEST(test_fifteen_yields_plingplang);
-   RUN_TEST(test_twenty_one_yields_plingplong);
-   RUN_TEST(test_twenty_five_yields_plang);
-   RUN_TEST(test_thirty_five_yields_plangplong);
-   RUN_TEST(test_forty_nine_yields_plong);
-   RUN_TEST(test_fifty_two_yields_itself);
-   RUN_TEST(test_one_hundred_five_yields_plingplangplong);
-   RUN_TEST(test_big_prime_yields_itself);
    RUN_TEST(test_no_buffer_overflow_for_plingplangplong);
    RUN_TEST(test_no_buffer_overflow_for_number);
 


### PR DESCRIPTION
I am assuming this was an unintentional copy/paste error.  If it was intentional then reject this change.  If you let me know the pedagogical reason for running these tests twice I can add a comment, and my guess is we can get the same benefit just duplicating a couple. 