### PR TITLE
Updated unequal length tests in hamming

### DIFF
--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -4,13 +4,15 @@
 
 size_t compute(const char *lhs, const char *rhs)
 {
-   size_t lhs_len = strlen(lhs);
-   size_t rhs_len = strlen(rhs);
-   size_t count = 0;
-   size_t i = 0;
-   for (i = 0; i < lhs_len && i < rhs_len; ++i) {
-      if (lhs[i] != rhs[i]) {
-         ++count;
+   size_t count = -1;
+   if ( lhs && rhs && (strlen(lhs)==strlen(rhs))){
+      count++;
+      size_t lhs_len = strlen(lhs);
+      size_t i = 0;
+      for (i = 0; i < lhs_len; ++i) {
+         if (lhs[i] != rhs[i]) {
+            ++count;
+         }
       }
    }
    return count;

--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -7,7 +7,8 @@ size_t compute(const char *lhs, const char *rhs)
    size_t count = -1;
    if (lhs && rhs && (strlen(lhs) == strlen(rhs))) {
       count = 0;
-      for (size_t i = 0; i < strlen(lhs); ++i) {
+      size_t length = strlen(lhs);
+      for (size_t i = 0; i < length; ++i) {
          if (lhs[i] != rhs[i]) {
             ++count;
          }

--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -2,13 +2,13 @@
 #include <string.h>
 #include "hamming.h"
 
-size_t compute(const char *lhs, const char *rhs)
+int compute(const char *lhs, const char *rhs)
 {
-   size_t count = -1;
+   int count = -1;
    if (lhs && rhs && (strlen(lhs) == strlen(rhs))) {
       count = 0;
-      size_t length = strlen(lhs);
-      for (size_t i = 0; i < length; ++i) {
+      int length = (int)strlen(lhs);
+      for (int i = 0; i < length; ++i) {
          if (lhs[i] != rhs[i]) {
             ++count;
          }

--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -6,10 +6,8 @@ size_t compute(const char *lhs, const char *rhs)
 {
    size_t count = -1;
    if (lhs && rhs && (strlen(lhs) == strlen(rhs))) {
-      count++;
-      size_t lhs_len = strlen(lhs);
-      size_t i = 0;
-      for (i = 0; i < lhs_len; ++i) {
+      count = 0;
+      for (size_t i = 0; i < strlen(lhs); ++i) {
          if (lhs[i] != rhs[i]) {
             ++count;
          }

--- a/exercises/hamming/src/example.c
+++ b/exercises/hamming/src/example.c
@@ -5,7 +5,7 @@
 size_t compute(const char *lhs, const char *rhs)
 {
    size_t count = -1;
-   if ( lhs && rhs && (strlen(lhs)==strlen(rhs))){
+   if (lhs && rhs && (strlen(lhs) == strlen(rhs))) {
       count++;
       size_t lhs_len = strlen(lhs);
       size_t i = 0;

--- a/exercises/hamming/src/example.h
+++ b/exercises/hamming/src/example.h
@@ -1,6 +1,6 @@
 #ifndef HAMMING_H
 #define HAMMING_H
 
-size_t compute(const char *lhs, const char *rhs);
+int compute(const char *lhs, const char *rhs);
 
 #endif

--- a/exercises/hamming/test/test_hamming.c
+++ b/exercises/hamming/test/test_hamming.c
@@ -1,9 +1,29 @@
 #include "vendor/unity.h"
 #include "../src/hamming.h"
 
+void test_empty_strands(void)
+{
+    TEST_ASSERT_EQUAL(0, compute("", ""));
+}
+
+void test_rejects_null_strand(void)
+{
+   TEST_ASSERT_EQUAL(-1, compute(NULL, "A"));
+}
+
+void test_rejects_other_null_strand(void)
+{
+    TEST_ASSERT_EQUAL(-1, compute("A", NULL));
+}
+
 void test_no_difference_between_identical_strands(void)
 {
-   TEST_ASSERT_EQUAL(0, compute("A", "A"));
+    TEST_ASSERT_EQUAL(0, compute("A", "A"));
+}
+
+void test_identical_long_strands(void)
+{
+    TEST_ASSERT_EQUAL(0, compute("GGACTGA", "GGACTGA"));
 }
 
 void test_hamming_distance_for_single_nucleotide_strand(void)
@@ -26,14 +46,14 @@ void test_small_hamming_distance_in_longer_strand(void)
    TEST_ASSERT_EQUAL(1, compute("GGACG", "GGTCG"));
 }
 
-void test_ignores_extra_length_on_first_strand_when_longer(void)
+void test_rejects_extra_length_on_first_strand_when_longer(void)
 {
-   TEST_ASSERT_EQUAL(1, compute("CAAG", "AAA"));
+   TEST_ASSERT_EQUAL(-1, compute("AAAG", "AAA"));
 }
 
-void test_ignores_extra_length_on_other_strand_when_longer(void)
+void test_rejects_extra_length_on_other_strand_when_longer(void)
 {
-   TEST_ASSERT_EQUAL(1, compute("AAA", "ACAG"));
+   TEST_ASSERT_EQUAL(-1, compute("AAA", "AAAG"));
 }
 
 void test_large_hamming_distance(void)
@@ -50,13 +70,17 @@ int main(void)
 {
    UnityBegin("hamming.c");
 
+   RUN_TEST(test_empty_strands);
    RUN_TEST(test_no_difference_between_identical_strands);
+   RUN_TEST(test_rejects_null_strand);
+   RUN_TEST(test_rejects_other_null_strand);
+   RUN_TEST(test_identical_long_strands);
    RUN_TEST(test_hamming_distance_for_single_nucleotide_strand);
    RUN_TEST(test_complete_hamming_distance_for_small_strand);
    RUN_TEST(test_small_hamming_distance);
    RUN_TEST(test_small_hamming_distance_in_longer_strand);
-   RUN_TEST(test_ignores_extra_length_on_first_strand_when_longer);
-   RUN_TEST(test_ignores_extra_length_on_other_strand_when_longer);
+   RUN_TEST(test_rejects_null_strand);
+   RUN_TEST(test_rejects_other_null_strand);
    RUN_TEST(test_large_hamming_distance);
    RUN_TEST(test_hamming_distance_in_very_long_strand);
 

--- a/exercises/hamming/test/test_hamming.c
+++ b/exercises/hamming/test/test_hamming.c
@@ -68,7 +68,7 @@ void test_hamming_distance_in_very_long_strand(void)
 
 int main(void)
 {
-   UnityBegin("hamming.c");
+   UnityBegin("test/test_hamming.c");
 
    RUN_TEST(test_empty_strands);
    RUN_TEST(test_no_difference_between_identical_strands);

--- a/exercises/hamming/test/test_hamming.c
+++ b/exercises/hamming/test/test_hamming.c
@@ -3,7 +3,7 @@
 
 void test_empty_strands(void)
 {
-    TEST_ASSERT_EQUAL(0, compute("", ""));
+   TEST_ASSERT_EQUAL(0, compute("", ""));
 }
 
 void test_rejects_null_strand(void)
@@ -13,17 +13,17 @@ void test_rejects_null_strand(void)
 
 void test_rejects_other_null_strand(void)
 {
-    TEST_ASSERT_EQUAL(-1, compute("A", NULL));
+   TEST_ASSERT_EQUAL(-1, compute("A", NULL));
 }
 
 void test_no_difference_between_identical_strands(void)
 {
-    TEST_ASSERT_EQUAL(0, compute("A", "A"));
+   TEST_ASSERT_EQUAL(0, compute("A", "A"));
 }
 
 void test_identical_long_strands(void)
 {
-    TEST_ASSERT_EQUAL(0, compute("GGACTGA", "GGACTGA"));
+   TEST_ASSERT_EQUAL(0, compute("GGACTGA", "GGACTGA"));
 }
 
 void test_hamming_distance_for_single_nucleotide_strand(void)

--- a/exercises/hamming/test/test_hamming.c
+++ b/exercises/hamming/test/test_hamming.c
@@ -28,12 +28,12 @@ void test_small_hamming_distance_in_longer_strand(void)
 
 void test_ignores_extra_length_on_first_strand_when_longer(void)
 {
-   TEST_ASSERT_EQUAL(0, compute("AAAG", "AAA"));
+   TEST_ASSERT_EQUAL(1, compute("CAAG", "AAA"));
 }
 
 void test_ignores_extra_length_on_other_strand_when_longer(void)
 {
-   TEST_ASSERT_EQUAL(0, compute("AAA", "AAAG"));
+   TEST_ASSERT_EQUAL(1, compute("AAA", "ACAG"));
 }
 
 void test_large_hamming_distance(void)


### PR DESCRIPTION
These two tests were ambiguous:
```
void test_ignores_extra_length_on_first_strand_when_longer(void)
{
   TEST_ASSERT_EQUAL(0, compute("AAAG", "AAA"));
}

void test_ignores_extra_length_on_other_strand_when_longer(void)
{
   TEST_ASSERT_EQUAL(0, compute("AAA", "AAAG"));
}
```
The title says ignore extra length, but  completely ignoring two different length strands would also pass. 
I fixed so you had to compare the first 3 letters to pass.
I could also change so you had to drop.
A 3rd choice, that is a little more rework is to go back and return -1 for errors.
Let me know if you want one of the other choices.