### PR TITLE
Added test cases for nullptr and empty string to acronym

### DIFF
--- a/exercises/acronym/src/example.c
+++ b/exercises/acronym/src/example.c
@@ -4,8 +4,8 @@
 static int is_first_letter_of_word(int character, int preceding_character)
 {
    return isalpha(character)
-       && ((preceding_character == ' ')
-           || (preceding_character == '-')) ? 1 : 0;
+   && ((preceding_character == ' ')
+       || (preceding_character == '-')) ? 1 : 0;
 }
 
 static int count_words(const char phrase[])
@@ -38,7 +38,8 @@ char *abbreviate(const char phrase[])
 
    for (size_t i = 1, j = 1; phrase[i] != '\0'; ++i) {
       if (is_first_letter_of_word(phrase[i], phrase[i - 1]))
-         acronym[j++] = toupper(phrase[i]);     /* first letter of subsequent words */
+         acronym[j++] = toupper(phrase[i]);     /* first letter of subsequent
+                                                   words */
    }
    return acronym;
 }

--- a/exercises/acronym/src/example.c
+++ b/exercises/acronym/src/example.c
@@ -4,8 +4,8 @@
 static int is_first_letter_of_word(int character, int preceding_character)
 {
    return isalpha(character)
-   && ((preceding_character == ' ')
-       || (preceding_character == '-')) ? 1 : 0;
+       && ((preceding_character == ' ')
+           || (preceding_character == '-')) ? 1 : 0;
 }
 
 static int count_words(const char phrase[])
@@ -38,8 +38,7 @@ char *abbreviate(const char phrase[])
 
    for (size_t i = 1, j = 1; phrase[i] != '\0'; ++i) {
       if (is_first_letter_of_word(phrase[i], phrase[i - 1]))
-         acronym[j++] = toupper(phrase[i]);     /* first letter of subsequent
-                                                   words */
+         acronym[j++] = toupper(phrase[i]);     /* first letter of subsequent words */
    }
    return acronym;
 }

--- a/exercises/acronym/test/test_acronym.c
+++ b/exercises/acronym/test/test_acronym.c
@@ -10,6 +10,20 @@ void test_abbreviation(char *phrase, char *expected)
    free(actual);
 }
 
+void test_null_string(void)
+{
+    char *phrase = NULL;
+    char *expected = NULL;
+    test_abbreviation(phrase, expected);
+}
+
+void test_empty_string(void)
+{
+    char *phrase = "";
+    char *expected = NULL;
+    test_abbreviation(phrase, expected);
+}
+
 void test_basic_abbreviation(void)
 {
    char *phrase = "Portable Network Graphics";
@@ -57,6 +71,8 @@ int main(void)
    UnityBegin("test/test_acronym.c");
 
    RUN_TEST(test_basic_abbreviation);
+   RUN_TEST(test_null_string);
+   RUN_TEST(test_empty_string);
    RUN_TEST(test_lower_case_words);
    RUN_TEST(test_punctuation);
    RUN_TEST(test_all_caps_words);

--- a/exercises/acronym/test/test_acronym.c
+++ b/exercises/acronym/test/test_acronym.c
@@ -12,16 +12,16 @@ void test_abbreviation(char *phrase, char *expected)
 
 void test_null_string(void)
 {
-    char *phrase = NULL;
-    char *expected = NULL;
-    test_abbreviation(phrase, expected);
+   char *phrase = NULL;
+   char *expected = NULL;
+   test_abbreviation(phrase, expected);
 }
 
 void test_empty_string(void)
 {
-    char *phrase = "";
-    char *expected = NULL;
-    test_abbreviation(phrase, expected);
+   char *phrase = "";
+   char *expected = NULL;
+   test_abbreviation(phrase, expected);
 }
 
 void test_basic_abbreviation(void)


### PR DESCRIPTION
I added the test cases for nullptr and empty string to match the example implementation.  We can change the expected results and the example implementation if you want.  Second test should maybe return "", but either way is OK. 