### PR TITLE
Update robot simulator exercise to snake case

### DIFF
--- a/exercises/robot-simulator/src/example.c
+++ b/exercises/robot-simulator/src/example.c
@@ -1,48 +1,48 @@
 #include <string.h>
 #include "robot_simulator.h"
 
-RobotGridStatus_t robot_init(void)
+robot_grid_status_t robot_init(void)
 {
    return (robot_init_with_position
-           (Default_Bearing, Default_X_Coordinate, Default_Y_Coordinate));
+           (default_bearing, default_x_coordinate, default_y_coordinate));
 }
 
-RobotGridStatus_t robot_init_with_position(int bearing, int x, int y)
+robot_grid_status_t robot_init_with_position(int bearing, int x, int y)
 {
-   RobotGridStatus_t robot = { bearing, {x, y} };
+   robot_grid_status_t robot = { bearing, {x, y} };
 
-   if ((bearing < Heading_North) || (bearing >= Heading_Max)) {
-      robot.bearing = Default_Bearing;
+   if ((bearing < heading_north) || (bearing >= heading_max)) {
+      robot.bearing = default_bearing;
    }
    return robot;
 }
 
-void robot_turn_right(RobotGridStatus_t * robot)
+void robot_turn_right(robot_grid_status_t * robot)
 {
-   robot->bearing = (robot->bearing + 1) % Heading_Max;
+   robot->bearing = (robot->bearing + 1) % heading_max;
 }
 
-void robot_turn_left(RobotGridStatus_t * robot)
+void robot_turn_left(robot_grid_status_t * robot)
 {
-   robot->bearing = ((robot->bearing - 1) + Heading_Max) % Heading_Max;
+   robot->bearing = ((robot->bearing - 1) + heading_max) % heading_max;
 }
 
-void robot_advance(RobotGridStatus_t * robot)
+void robot_advance(robot_grid_status_t * robot)
 {
    switch (robot->bearing) {
-   case Heading_North:
+   case heading_north:
       robot->grid.y_position++;
       break;
 
-   case Heading_East:
+   case heading_east:
       robot->grid.x_position++;
       break;
 
-   case Heading_South:
+   case heading_south:
       robot->grid.y_position--;
       break;
 
-   case Heading_West:
+   case heading_west:
       robot->grid.x_position--;
       break;
 
@@ -51,19 +51,19 @@ void robot_advance(RobotGridStatus_t * robot)
    }
 }
 
-void robot_simulator(RobotGridStatus_t * robot, const char *commands)
+void robot_simulator(robot_grid_status_t * robot, const char *commands)
 {
    for (unsigned long index = 0; index < strlen(commands); index++) {
       switch (commands[index]) {
-      case Command_Left:
+      case command_left:
          robot_turn_left(robot);
          break;
 
-      case Command_Right:
+      case command_right:
          robot_turn_right(robot);
          break;
 
-      case Command_Advance:
+      case command_advance:
          robot_advance(robot);
          break;
 

--- a/exercises/robot-simulator/src/robot_simulator.h
+++ b/exercises/robot-simulator/src/robot_simulator.h
@@ -2,40 +2,40 @@
 #define ROBOT_SIMULATOR_H
 
 typedef enum {
-   Heading_North = 0,
-   Heading_East,
-   Heading_South,
-   Heading_West,
-   Heading_Max
-} Bearing_t;
+   heading_north = 0,
+   heading_east,
+   heading_south,
+   heading_west,
+   heading_max
+} bearing_t;
 
 enum {
-   Default_Bearing = Heading_North,
-   Default_X_Coordinate = 0,
-   Default_Y_Coordinate = 0,
+   default_bearing = heading_north,
+   default_x_coordinate = 0,
+   default_y_coordinate = 0,
 };
 
 enum {
-   Command_Left = 'L',
-   Command_Right = 'R',
-   Command_Advance = 'A'
+   command_left = 'L',
+   command_right = 'R',
+   command_advance = 'A'
 };
 
-typedef struct RobotCoordinates {
+typedef struct robot_coordinates {
    int x_position;
    int y_position;
-} RobotCoordinates_t;
+} robot_coordinates_t;
 
-typedef struct RobotGridStatus {
-   Bearing_t bearing;
-   RobotCoordinates_t grid;
-} RobotGridStatus_t;
+typedef struct robot_grid_status {
+   bearing_t bearing;
+   robot_coordinates_t grid;
+} robot_grid_status_t;
 
-RobotGridStatus_t robot_init(void);
-RobotGridStatus_t robot_init_with_position(int bearing, int x, int y);
-void robot_turn_right(RobotGridStatus_t * robot);
-void robot_turn_left(RobotGridStatus_t * robot);
-void robot_advance(RobotGridStatus_t * robot);
-void robot_simulator(RobotGridStatus_t * robot, const char *commands);
+robot_grid_status_t robot_init(void);
+robot_grid_status_t robot_init_with_position(int bearing, int x, int y);
+void robot_turn_right(robot_grid_status_t * robot);
+void robot_turn_left(robot_grid_status_t * robot);
+void robot_advance(robot_grid_status_t * robot);
+void robot_simulator(robot_grid_status_t * robot, const char *commands);
 
 #endif

--- a/exercises/robot-simulator/test/test_robot_simulator.c
+++ b/exercises/robot-simulator/test/test_robot_simulator.c
@@ -2,7 +2,8 @@
 #include "vendor/unity.h"
 
 // Test Helper Function
-void confirm_position(RobotGridStatus_t * expected, RobotGridStatus_t * actual)
+void confirm_position(robot_grid_status_t * expected,
+                      robot_grid_status_t * actual)
 {
    TEST_ASSERT_EQUAL(expected->bearing, actual->bearing);
    TEST_ASSERT_EQUAL(expected->grid.x_position, actual->grid.x_position);
@@ -12,9 +13,9 @@ void confirm_position(RobotGridStatus_t * expected, RobotGridStatus_t * actual)
 // Tests...
 void test_init(void)
 {
-   RobotGridStatus_t expected =
-       { Default_Bearing, {Default_X_Coordinate, Default_Y_Coordinate} };
-   RobotGridStatus_t actual = robot_init();
+   robot_grid_status_t expected =
+       { default_bearing, {default_x_coordinate, default_y_coordinate} };
+   robot_grid_status_t actual = robot_init();
 
    confirm_position(&expected, &actual);
 }
@@ -22,10 +23,10 @@ void test_init(void)
 void test_invalid_initial_heading(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   RobotGridStatus_t expected =
-       { Default_Bearing, {Default_X_Coordinate, Default_Y_Coordinate} };
-   RobotGridStatus_t actual =
-       robot_init_with_position(99, Default_X_Coordinate, Default_Y_Coordinate);
+   robot_grid_status_t expected =
+       { default_bearing, {default_x_coordinate, default_y_coordinate} };
+   robot_grid_status_t actual =
+       robot_init_with_position(99, default_x_coordinate, default_y_coordinate);
 
    confirm_position(&expected, &actual);
 }
@@ -33,8 +34,8 @@ void test_invalid_initial_heading(void)
 void test_init_with_negative_positions(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_South, {-1, -1} };
-   RobotGridStatus_t actual = robot_init_with_position(Heading_South, -1, -1);
+   robot_grid_status_t expected = { heading_south, {-1, -1} };
+   robot_grid_status_t actual = robot_init_with_position(heading_south, -1, -1);
 
    confirm_position(&expected, &actual);
 }
@@ -42,21 +43,21 @@ void test_init_with_negative_positions(void)
 void test_turn_right(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_East, {0, 0} };
-   RobotGridStatus_t actual = robot_init();
+   robot_grid_status_t expected = { heading_east, {0, 0} };
+   robot_grid_status_t actual = robot_init();
 
    robot_turn_right(&actual);
    confirm_position(&expected, &actual);
 
-   expected.bearing = Heading_South;
+   expected.bearing = heading_south;
    robot_turn_right(&actual);
    confirm_position(&expected, &actual);
 
-   expected.bearing = Heading_West;
+   expected.bearing = heading_west;
    robot_turn_right(&actual);
    confirm_position(&expected, &actual);
 
-   expected.bearing = Heading_North;
+   expected.bearing = heading_north;
    robot_turn_right(&actual);
    confirm_position(&expected, &actual);
 }
@@ -64,21 +65,21 @@ void test_turn_right(void)
 void test_turn_left(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_West, {0, 0} };
-   RobotGridStatus_t actual = robot_init();
+   robot_grid_status_t expected = { heading_west, {0, 0} };
+   robot_grid_status_t actual = robot_init();
 
    robot_turn_left(&actual);
    confirm_position(&expected, &actual);
 
-   expected.bearing = Heading_South;
+   expected.bearing = heading_south;
    robot_turn_left(&actual);
    confirm_position(&expected, &actual);
 
-   expected.bearing = Heading_East;
+   expected.bearing = heading_east;
    robot_turn_left(&actual);
    confirm_position(&expected, &actual);
 
-   expected.bearing = Heading_North;
+   expected.bearing = heading_north;
    robot_turn_left(&actual);
    confirm_position(&expected, &actual);
 }
@@ -86,8 +87,8 @@ void test_turn_left(void)
 void test_advance_positive_north(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_North, {0, 1} };
-   RobotGridStatus_t actual = robot_init();
+   robot_grid_status_t expected = { heading_north, {0, 1} };
+   robot_grid_status_t actual = robot_init();
 
    robot_advance(&actual);
    confirm_position(&expected, &actual);
@@ -96,8 +97,8 @@ void test_advance_positive_north(void)
 void test_advance_positive_east(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_East, {1, 0} };
-   RobotGridStatus_t actual = robot_init_with_position(Heading_East, 0, 0);
+   robot_grid_status_t expected = { heading_east, {1, 0} };
+   robot_grid_status_t actual = robot_init_with_position(heading_east, 0, 0);
 
    robot_advance(&actual);
    confirm_position(&expected, &actual);
@@ -106,8 +107,8 @@ void test_advance_positive_east(void)
 void test_advance_negative_south(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_South, {0, -1} };
-   RobotGridStatus_t actual = robot_init_with_position(Heading_South, 0, 0);
+   robot_grid_status_t expected = { heading_south, {0, -1} };
+   robot_grid_status_t actual = robot_init_with_position(heading_south, 0, 0);
 
    robot_advance(&actual);
    confirm_position(&expected, &actual);
@@ -116,8 +117,8 @@ void test_advance_negative_south(void)
 void test_advance_negative_west(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_West, {-1, 0} };
-   RobotGridStatus_t actual = robot_init_with_position(Heading_West, 0, 0);
+   robot_grid_status_t expected = { heading_west, {-1, 0} };
+   robot_grid_status_t actual = robot_init_with_position(heading_west, 0, 0);
 
    robot_advance(&actual);
    confirm_position(&expected, &actual);
@@ -126,8 +127,8 @@ void test_advance_negative_west(void)
 void test_simulate_move_west_and_north(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_West, {-4, 1} };
-   RobotGridStatus_t actual = robot_init();
+   robot_grid_status_t expected = { heading_west, {-4, 1} };
+   robot_grid_status_t actual = robot_init();
 
    robot_simulator(&actual, "LAAARALA");
    confirm_position(&expected, &actual);
@@ -136,8 +137,8 @@ void test_simulate_move_west_and_north(void)
 void test_simulate_move_west_and_south(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_South, {-3, -8} };
-   RobotGridStatus_t actual = robot_init_with_position(Heading_East, 2, -7);
+   robot_grid_status_t expected = { heading_south, {-3, -8} };
+   robot_grid_status_t actual = robot_init_with_position(heading_east, 2, -7);
 
    robot_simulator(&actual, "RRAAAAALA");
    confirm_position(&expected, &actual);
@@ -146,8 +147,8 @@ void test_simulate_move_west_and_south(void)
 void test_simulate_move_east_and_north(void)
 {
    TEST_IGNORE();
-   RobotGridStatus_t expected = { Heading_North, {11, 5} };
-   RobotGridStatus_t actual = robot_init_with_position(Heading_South, 8, 4);
+   robot_grid_status_t expected = { heading_north, {11, 5} };
+   robot_grid_status_t actual = robot_init_with_position(heading_south, 8, 4);
 
    robot_simulator(&actual, "LAAARRRALLLL");
    confirm_position(&expected, &actual);


### PR DESCRIPTION
Update robot simulator exercise to snake case per #184 

Am unsure about enum members casing. IIRC the Linux kernel style is to use all-cap snake case, like:

```c
enum {
        LIKE_THIS
}
```

But from memory I don't think any of the other exercises use this so have left all lower for now.