### PR TITLE
Add a contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ To get an idea of the general status in relation to the launch of the track, che
 
 ## Contributing
 
-Contributions are very welcome! Please see the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md) to get started.
-
-## Coding Style
-
-Please see the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md) for information on style and the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md#coding-style) for information on installing and using `indent` when making changes to exercises.
+Contributions are very welcome! Please see the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md) to get started. The guide contains general contribution tips, information on the code style, information on the continuous integration used and the anatomy of an exercise on this language track.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Contributions are very welcome! Please see the [contributing guide](https://gith
 
 ## Coding Style
 
-Please see the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md) for information on style and the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md#coding-style) for information on using `indent` when making changes to exercises.
-
-If GNU `indent` is installed, this can be run on all files by executing `indent.sh`. On a Mac you can install the package `gnu-indent` using [Homebrew](http://brew.sh).
+Please see the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md) for information on style and the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md#coding-style) for information on installing and using `indent` when making changes to exercises.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,51 +12,15 @@ Issues marked with these labels are a good place to start contributing - you are
 
 To get an idea of the general status in relation to the launch of the track, check out [issue #8](https://github.com/exercism/c/issues/8)
 
-## Contributing Guide
+## Contributing
 
-Please see the [Exercism contributing guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md) for general contribution tips.
+Contributions are very welcome! Please see the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md) to get started.
 
 ## Coding Style
 
-All test and example code should be written using the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs.
+Please see the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md) for information on style and the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md#coding-style) for information on using `indent` when making changes to exercises.
 
 If GNU `indent` is installed, this can be run on all files by executing `indent.sh`. On a Mac you can install the package `gnu-indent` using [Homebrew](http://brew.sh).
-
-To manually run it on a single file, you can execute:
-
-```shell
-indent -linux -i3 -nut $(file)
-```
-
-If your system does not support the `-linux` option, you can run the long form command instead:
-
-```shell
-indent -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4 -cli0 -d0 -di1 -nfc1 -i3 -nut -ip0 -l80 -lp -npcs -nprs -npsl -sai -saf -saw -ncs -nsc -sob -nfca -cp33 -ss -il1 $(file)
-```
-
-See the [GNU `indent` manual](https://www.gnu.org/software/indent/manual/indent.html#SEC4) for more information.
-
-## Exercise Anatomy
-
-Each exercise should be contained in a directory ```c/exercises/<my exercise>``` with ```<my exercise>``` referring to the name of the exercise.  The structure of the directory is as follows:
-
-```
-+-- <my exercise>
-    +-- makefile
-    +-- src
-    |   +-- example.c
-    |   +-- example.h | <my exercise>.h
-    +-- test
-        +-- test_<my exercise>.c
-        +-- vendor
-            +-- unity.c
-            +-- unity.h
-            +-- unity_internals.h
-```
-
-* `test` - contains the test file ```test_<my exercise>.c``` and a ```vendor``` directory containing the test harness [Unity](http://www.throwtheswitch.org/unity/) from [ThrowTheSwitch](http://www.throwtheswitch.org/#intro-1-section).  ThrowTheSwitch has a decent guide on [getting started with Unity](http://www.throwtheswitch.org/getting-started-with-unity/) should you desire a tutorial.
-
-* `src` - contains the example files ```example.c``` and ```example.h```. These are both skipped by the ```exercism``` cli when downloading to the client, so it is imperative that you do not reference the names of the files in your code. If you need to provide a header file example that is necessary to run your tests it should be named ```<my exercise>.h``` instead.  Please also use [```include```](http://faculty.cs.niu.edu/~mcmahon/CS241/c241man/node90.html) guards in your header files. The tests can be run using the [```bin/run-tests```](https://github.com/exercism/c/blob/master/bin/run-tests) script which will rename the ```example.{c|h}``` files accordingly.
 
 ## License
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to the C Track
+
+Thank you for interest in contributing to the Exercism C language track! 
+All contributions are welcome, be it a new exercise, a change to the tooling or documentation, a raised issue or even just a commment on an existing issue or PR.
+This file provides information to help you get started.
+
+Firstly, have a read of the Exercism [docs repository](https://github.com/exercism/docs), specifically the information on [contributing to a language track](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md), as these documents covers a lot of the basic information.
+
+Subsequently there are a few things specific to this repository that are explained below.
+
+## Coding Style
+
+The exercise code is checked during CI for conformance to a set of style rules. The check uses the GNU indent CLI tool.
+When adding or making a change to an exercise, you can check your change conforms to these rules by running the tool locally.
+
+The style rules used are explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md). 
+In short, they equate to the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs.
+
+To install the tool, please see the [install indent guide](#).
+
+Indent can be run on all files by executing `indent.sh`.
+To manually run it on a single file, you can execute:
+
+```bash
+indent -linux -i3 -nut $(file)
+```
+
+If your system does not support the `-linux` option, you can run the long-form command instead:
+
+```bash
+indent -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4 -cli0 -d0 -di1 -nfc1 -i3 -nut -ip0 -l80 -lp -npcs -nprs -npsl -sai -saf -saw -ncs -nsc -sob -nfca -cp33 -ss -il1 $(file)
+```
+
+## Continuous Integration
+
+**TODO: THE TRAVIS CHECKS AND HOW TO RUN THEM LOCALLY**
+
+## Exercise anatomy
+
+Each exercise should be contained in a directory `c/exercises/<my exercise>` with `<my exercise>` referring to the name of the exercise. 
+The structure of the directory is as follows:
+
+```
++-- <my exercise>
+    +-- makefile
+    +-- src
+    |   +-- example.c
+    |   +-- example.h | <my exercise>.h
+    +-- test
+        +-- test_<my exercise>.c
+        +-- vendor
+            +-- unity.c
+            +-- unity.h
+            +-- unity_internals.h
+```
+
+* `test` - contains the test file `test_<my exercise>.c` and a `vendor` directory containing the test harness [Unity](http://www.throwtheswitch.org/unity/) from [ThrowTheSwitch](http://www.throwtheswitch.org/#intro-1-section).
+ThrowTheSwitch has a decent guide on [getting started with Unity](http://www.throwtheswitch.org/getting-started-with-unity/) should you desire a tutorial.
+
+* `src` - contains the example files `example.c` and `example.h`. These are both skipped by the `exercism` CLI when downloading to the client, so it is imperative that you do not reference the names of the files in your code. 
+If you need to provide a header file example that is necessary to run your tests it should be named `<my exercise>.h` instead.
+Please also use [`include`](http://faculty.cs.niu.edu/~mcmahon/CS241/c241man/node90.html) guards in your header files. 
+The tests can be run using the [`bin/run-tests`](https://github.com/exercism/c/blob/master/bin/run-tests) script which will rename the `example.{c|h}` files accordingly.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Subsequently note that there are a few things specific to this repository that a
 
 ## Coding Style
 
-The exercise code is checked during CI for conformance to a set of style rules. The check uses the GNU `indent` CLI tool.
-When adding or making a change to an exercise, you can check that your change conforms to these rules by running the tool locally before commiting.
+The code style expected for code change contributions is explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md#indentation-and-format). 
+In short, they equate to the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs, and snake cased names.
 
-The style rules used are explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md#indentation-and-format). 
-In short, they equate to the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs.
+The exercise code is checked during CI for conformance to the spacing and indentation style rules. The check uses the GNU `indent` CLI tool.
+When adding or making a change to an exercise, you can check that your change conforms to these rules by running the tool locally before commiting.
 
 On linux `indent` should be available for install via your distribution's package manager. 
 On a Mac you can install the package `gnu-indent` using [Homebrew](https://brew.sh).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,8 @@ When adding or making a change to an exercise, you can check your change conform
 The style rules used are explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md#indentation-and-format). 
 In short, they equate to the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs.
 
-To install the tool, please see the [install indent guide](#).
+On linux `indent` should be available for install via your distribution's package manager. 
+On a Mac you can install the package `gnu-indent` using [Homebrew](https://brew.sh).
 
 Indent can be run on all files by executing `indent.sh`.
 To manually run it on a single file, you can execute:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Thank you for interest in contributing to the Exercism C language track!
 All contributions are welcome, be it a new exercise, a change to the tooling or documentation, a raised issue or even just a commment on an existing issue or PR.
 This file provides information to help you get started.
 
-Firstly, have a read of the Exercism [docs repository](https://github.com/exercism/docs), specifically the information on [contributing to a language track](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md), as these documents covers a lot of the basic information.
+Firstly, have a read of the Exercism [docs repository](https://github.com/exercism/docs), specifically the information on [contributing to a language track](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md), as these documents cover a lot of the basic information.
 
-Subsequently there are a few things specific to this repository that are explained below.
+Subsequently note that there are a few things specific to this repository that are explained below.
 
 ## Coding Style
 
-The exercise code is checked during CI for conformance to a set of style rules. The check uses the GNU indent CLI tool.
-When adding or making a change to an exercise, you can check your change conforms to these rules by running the tool locally.
+The exercise code is checked during CI for conformance to a set of style rules. The check uses the GNU `indent` CLI tool.
+When adding or making a change to an exercise, you can check that your change conforms to these rules by running the tool locally before commiting.
 
 The style rules used are explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md#indentation-and-format). 
 In short, they equate to the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs.
@@ -34,7 +34,36 @@ indent -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4 -cli0 -d0 -d
 
 ## Continuous Integration
 
-**TODO: THE TRAVIS CHECKS AND HOW TO RUN THEM LOCALLY**
+The repository uses Travis CI to run some scripts on each commit to a pull request. 
+The simplest way to run these scripts on your own contribution is to open a PR on this repository with your changes, mark the title as [WIP] so that maintainers know that it isn't quite ready to be merged just yet and then allow this repository's CI setup to take care of things for you automatically.
+
+### Run CI on Your Own Fork
+
+If you would like, it is also possible to run Travis on your own fork. 
+The good folks at fish-shell have [some great information](https://github.com/fish-shell/fish-shell/blob/master/CONTRIBUTING.md#travis-ci-build-and-test) to help you get started with setting up Travis on your own fork.
+
+### Run CI Scripts Locally
+You can also run individual scripts on your own machine before commiting. 
+Firstly make sure you have the necessary tools installed (such as `indent`, `git`, `sed`, `make`, `valgrind` and a C compiler), and then run the required script from the repoistory root. For example:
+
+```bash
+~/git/c$ ./bin/run-tests
+```
+
+### What Are the CI Scripts?
+You can see from the [.travis.yml](https://github.com/exercism/c/blob/master/.travis.yml) file that Travis is instructed to run scripts from the [`./bin`](https://github.com/exercism/c/tree/master/bin) directory. 
+The work these scripts perform is descibed as folows:
+
+- `fetch-configlet` just fetches the `configlet` tool from its [repository](https://github.com/exercism/configlet).
+
+- `configlet` is a tool, specific to Exercism, that performs some repository management tasks. 
+The command for `configlet` used by Travis is [`lint`](https://github.com/exercism/configlet/blob/master/README.md#lint). If `configlet` finds any issues Travis will output the details and report a failure on the related PR.
+
+- `verify-indent` runs `indent` and verifies that it did not result in any file changes. 
+If the check does result in file changes, Travis will output the details and report a failure on the related PR.
+
+- `run-tests` loops through each exercise, prepares the exercise for building and then builds it using `make` and runs `valgrind`. 
+If there are build errors, any test fails or there is a memory leak, Travis will output the details and report a failure on the related PR.
 
 ## Exercise anatomy
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Subsequently there are a few things specific to this repository that are explain
 The exercise code is checked during CI for conformance to a set of style rules. The check uses the GNU indent CLI tool.
 When adding or making a change to an exercise, you can check your change conforms to these rules by running the tool locally.
 
-The style rules used are explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md). 
+The style rules used are explained in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md#indentation-and-format). 
 In short, they equate to the [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html) with 3 space indents and no tabs.
 
 To install the tool, please see the [install indent guide](#).
@@ -55,7 +55,7 @@ The structure of the directory is as follows:
 ```
 
 * `test` - contains the test file `test_<my exercise>.c` and a `vendor` directory containing the test harness [Unity](http://www.throwtheswitch.org/unity/) from [ThrowTheSwitch](http://www.throwtheswitch.org/#intro-1-section).
-ThrowTheSwitch has a decent guide on [getting started with Unity](http://www.throwtheswitch.org/getting-started-with-unity/) should you desire a tutorial.
+ThrowTheSwitch has a decent guide on [getting started with Unity](http://www.throwtheswitch.org/getting-started-with-unity/) should you desire a tutorial. The layout of the test file is described in the [style guide](https://github.com/exercism/c/blob/master/docs/C_STYLE_GUIDE.md#test-file-layout).
 
 * `src` - contains the example files `example.c` and `example.h`. These are both skipped by the `exercism` CLI when downloading to the client, so it is imperative that you do not reference the names of the files in your code. 
 If you need to provide a header file example that is necessary to run your tests it should be named `<my exercise>.h` instead.

--- a/docs/C_STYLE_GUIDE.md
+++ b/docs/C_STYLE_GUIDE.md
@@ -51,7 +51,7 @@ The correct prototype, providing that all other declarations and the definition 
 
 ## Indentation and Format
 
-The repository uses GNU `indent`, as outlined in the [README](https://github.com/exercism/c/blob/master/README.md).
+The repository uses the `indent` tool, as outlined in the [contributing guide](https://github.com/exercism/c/blob/master/docs/CONTRIBUTING.md).
 
 The options described for use with indent there are `-linux -i3 -nut`. The `-linux` option is a shortcut that is equivelent to a secific fixed group of options. The combined equivalent options are `-nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4 -cli0 -d0 -di1 -nfc1 -i3 -nut -ip0 -l80 -lp -npcs -nprs -npsl -sai -saf -saw -ncs -nsc -sob -nfca -cp33 -ss -il1`.
 


### PR DESCRIPTION
Start a contributing guide by collating information from the README and links to other relevant information. This allows us to extend the information beyond the scope of the README. Item in point, the CI information.

speaking of which, I don't actually know a huge amount about what Travis does (other than run the tests and indent check) so maybe someone else could contribute on that point in a more concise manner than I?