### PR TITLE
Triangle: change parameter from pointer to a struct

### DIFF
--- a/exercises/triangle/src/example.c
+++ b/exercises/triangle/src/example.c
@@ -1,30 +1,30 @@
 #include "triangle.h"
 
-bool triangle_equality(triangle_t * input)
+bool triangle_equality(triangle_t input)
 {
-   return (input->a < (input->b + input->c)
-           && input->b < (input->a + input->c)
-           && input->c < (input->a + input->b)
+   return (input.a < (input.b + input.c)
+           && input.b < (input.a + input.c)
+           && input.c < (input.a + input.b)
        );
 }
 
-bool is_equilateral(triangle_t * input)
+bool is_equilateral(triangle_t input)
 {
    return (triangle_equality(input)
-           && (input->a == input->b)
-           && (input->b == input->c)
+           && (input.a == input.b)
+           && (input.b == input.c)
        );
 }
 
-bool is_isosceles(triangle_t * input)
+bool is_isosceles(triangle_t input)
 {
-   return (triangle_equality(input) && ((input->a == input->b)
-                                        || (input->b == input->c)
-                                        || (input->a == input->c))
+   return (triangle_equality(input) && ((input.a == input.b)
+                                        || (input.b == input.c)
+                                        || (input.a == input.c))
        );
 }
 
-bool is_scalene(triangle_t * input)
+bool is_scalene(triangle_t input)
 {
    return (!(is_equilateral(input))
            && !(is_isosceles(input))

--- a/exercises/triangle/src/example.h
+++ b/exercises/triangle/src/example.h
@@ -8,8 +8,8 @@ typedef struct {
    double c;
 } triangle_t;
 
-bool is_equilateral(triangle_t * input);
-bool is_isosceles(triangle_t * input);
-bool is_scalene(triangle_t * input);
+bool is_equilateral(triangle_t input);
+bool is_isosceles(triangle_t input);
+bool is_scalene(triangle_t input);
 
 #endif

--- a/exercises/triangle/test/test_triangle.c
+++ b/exercises/triangle/test/test_triangle.c
@@ -12,112 +12,112 @@ void tearDown(void)
 void test_equilateral_is_true_if_all_sides_are_equal(void)
 {
    triangle_t sides = { 2, 2, 2 };
-   TEST_ASSERT_TRUE(is_equilateral(&sides));
+   TEST_ASSERT_TRUE(is_equilateral(sides));
 }
 
 void test_equilateral_is_false_if_any_side_is_unequal(void)
 {
    TEST_IGNORE();               // delete this line to run test
    triangle_t sides = { 2, 3, 2 };
-   TEST_ASSERT_FALSE(is_equilateral(&sides));
+   TEST_ASSERT_FALSE(is_equilateral(sides));
 }
 
 void test_equilateral_is_false_if_all_sides_zero(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 0, 0, 0 };
-   TEST_ASSERT_FALSE(is_equilateral(&sides));
+   TEST_ASSERT_FALSE(is_equilateral(sides));
 }
 
 void test_equilateral_sides_may_be_floats(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 0.5, 0.5, 0.5 };
-   TEST_ASSERT_TRUE(is_equilateral(&sides));
+   TEST_ASSERT_TRUE(is_equilateral(sides));
 }
 
 void test_isosceles_is_true_if_last_two_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 3, 4, 4 };
-   TEST_ASSERT_TRUE(is_isosceles(&sides));
+   TEST_ASSERT_TRUE(is_isosceles(sides));
 }
 
 void test_isosceles_is_true_if_first_two_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 4, 4, 3 };
-   TEST_ASSERT_TRUE(is_isosceles(&sides));
+   TEST_ASSERT_TRUE(is_isosceles(sides));
 }
 
 void test_isosceles_is_true_if_first_and_last_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 4, 3, 4 };
-   TEST_ASSERT_TRUE(is_isosceles(&sides));
+   TEST_ASSERT_TRUE(is_isosceles(sides));
 }
 
 void test_equilateral_triangles_are_also_isosceles(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 4, 4, 4 };
-   TEST_ASSERT_TRUE(is_isosceles(&sides));
+   TEST_ASSERT_TRUE(is_isosceles(sides));
 }
 
 void test_isosceles_is_false_if_no_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 2, 3, 4 };
-   TEST_ASSERT_FALSE(is_isosceles(&sides));
+   TEST_ASSERT_FALSE(is_isosceles(sides));
 }
 
 void test_isosceles_is_false_if_two_sides_equal_and_violate_inequality(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 1, 1, 3 };
-   TEST_ASSERT_FALSE(is_isosceles(&sides));
+   TEST_ASSERT_FALSE(is_isosceles(sides));
 }
 
 void test_isosceles_sides_may_be_floats(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 0.5, 0.4, 0.5 };
-   TEST_ASSERT_TRUE(is_isosceles(&sides));
+   TEST_ASSERT_TRUE(is_isosceles(sides));
 }
 
 void test_scalene_is_true_if_no_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 5, 4, 6 };
-   TEST_ASSERT_TRUE(is_scalene(&sides));
+   TEST_ASSERT_TRUE(is_scalene(sides));
 }
 
 void test_scalene_is_false_if_all_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 4, 4, 4 };
-   TEST_ASSERT_FALSE(is_scalene(&sides));
+   TEST_ASSERT_FALSE(is_scalene(sides));
 }
 
 void test_scalene_is_false_if_two_sides_are_equal(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 4, 4, 3 };
-   TEST_ASSERT_FALSE(is_scalene(&sides));
+   TEST_ASSERT_FALSE(is_scalene(sides));
 }
 
 void test_scalene_is_false_if_no_sides_equal_and_violate_inequality(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 7, 3, 2 };
-   TEST_ASSERT_FALSE(is_scalene(&sides));
+   TEST_ASSERT_FALSE(is_scalene(sides));
 }
 
 void test_scalene_sides_may_be_floats(void)
 {
    TEST_IGNORE();
    triangle_t sides = { 0.5, 0.4, 0.6 };
-   TEST_ASSERT_TRUE(is_scalene(&sides));
+   TEST_ASSERT_TRUE(is_scalene(sides));
 }
 
 int main(void)


### PR DESCRIPTION
The triangle exercise uses a pointer to a struct as the parameter to the functions that are to be implemented.

AFAICT there is no need for the parameter to be a pointer rather than the struct itself. As the exercise relates to structs rather than pointers, it seems an easy change to pass the structs by value to make it simpler to implement.