### PR TITLE
Add default maintainers file

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,0 +1,15 @@
+{
+  "maintainers": [
+    {
+      "github_username": "ryanplusplus",
+      "show_on_website": false,
+      "alumnus": false,
+      "name": null,
+      "bio": null,
+      "link_text": null,
+      "link_url": null,
+      "avatar_url": null
+    }
+  ],
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+}

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -9,6 +9,36 @@
       "link_text": null,
       "link_url": null,
       "avatar_url": null
+    },
+    {
+      "github_username": "patricksjackson",
+      "show_on_website": false,
+      "alumnus": false,
+      "name": null,
+      "bio": null,
+      "link_text": null,
+      "link_url": null,
+      "avatar_url": null
+    }
+    {
+      "github_username": "RealBarretBrown",
+      "show_on_website": false,
+      "alumnus": false,
+      "name": null,
+      "bio": null,
+      "link_text": null,
+      "link_url": null,
+      "avatar_url": null
+    }
+    {
+      "github_username": "wolf99",
+      "show_on_website": false,
+      "alumnus": false,
+      "name": "Toby",
+      "bio": null,
+      "link_text": "My GitHub Profile",
+      "link_url": "https://github.com/wolf99",
+      "avatar_url": null
     }
   ],
   "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -19,7 +19,7 @@
       "link_text": null,
       "link_url": null,
       "avatar_url": null
-    }
+    },
     {
       "github_username": "RealBarretBrown",
       "show_on_website": false,
@@ -29,7 +29,7 @@
       "link_text": null,
       "link_url": null,
       "avatar_url": null
-    }
+    },
     {
       "github_username": "wolf99",
       "show_on_website": false,


### PR DESCRIPTION
Seems we missed out on https://github.com/exercism/meta/issues/20.
I'm unsure who else is (or was, alumnus are included too) actually officially a maintainer for the C track.

The issue mentions that maintainers should each maintain their own entry so I'll submit this one and the relevant people can add/subtract entries and details as they like.

Documentation on it is here https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md