### PR TITLE
Adding memory safety to phone_number tests.

### DIFF
--- a/exercises/phone-number/test/test_phone_number.c
+++ b/exercises/phone-number/test/test_phone_number.c
@@ -2,7 +2,7 @@
 #include "../src/phone_number.h"
 #include <stdlib.h>
 
-char *result;
+char *result = NULL;
 
 void setUp(void)
 {
@@ -10,7 +10,10 @@ void setUp(void)
 
 void tearDown(void)
 {
-   free(result);
+   if (result) {
+      free(result);
+   }
+   result = NULL;
 }
 
 void test_cleans_parens_dashes_and_spaces_from_the_number(void)

--- a/exercises/phone-number/test/test_phone_number.c
+++ b/exercises/phone-number/test/test_phone_number.c
@@ -2,7 +2,7 @@
 #include "../src/phone_number.h"
 #include <stdlib.h>
 
-char *result = NULL;
+static char *result = NULL;
 
 void setUp(void)
 {
@@ -10,9 +10,7 @@ void setUp(void)
 
 void tearDown(void)
 {
-   if (result) {
-      free(result);
-   }
+   free(result);
    result = NULL;
 }
 


### PR DESCRIPTION
Because blindly freeing a global pointer just screams scary to me. It's not really in this case, but having a dangling `free()` with no check and no zero'ing of the pointer might not be something we want the users to see.