### PR TITLE
hello-world: remove unneeded includes

### DIFF
--- a/exercises/hello-world/src/hello_world.c
+++ b/exercises/hello-world/src/hello_world.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-#include <stddef.h>
 #include "hello_world.h"
 
 const char *hello(void)


### PR DESCRIPTION
Seems the `hello_world.c`  stub still has two includes left in it from the previous implementation. This PR removes them. They are unneeded and could cause confusion or students that are very new to C. They also deviate from what is used in the `example.c` solution.