### PR TITLE
Updated sieve to use TEST_ASSERT_EQUAL_UINT_ARRAY instead of memcmp

### DIFF
--- a/exercises/sieve/test/test_sieve.c
+++ b/exercises/sieve/test/test_sieve.c
@@ -27,7 +27,7 @@ void test_no_primes_under_two(void)
 
 void test_find_first_prime(void)
 {
-   // delete this line to run test
+   TEST_IGNORE();               // delete this line to run test
    const unsigned int limit = 2;
    const primes_array_t expected_prime_array = { 2 };
    const unsigned int expected_prime_count = 1;
@@ -44,7 +44,7 @@ void test_find_first_prime(void)
 
 void test_find_primes_up_to_10(void)
 {
-
+   TEST_IGNORE();
    const unsigned int limit = 10;
    const primes_array_t expected_prime_array = { 2, 3, 5, 7 };
    const unsigned int expected_prime_count = 4;
@@ -61,7 +61,7 @@ void test_find_primes_up_to_10(void)
 
 void test_limit_is_prime(void)
 {
-
+   TEST_IGNORE();
    const unsigned int limit = 13;
    const primes_array_t expected_prime_array = { 2, 3, 5, 7, 11, 13 };
    const unsigned int expected_prime_count = 6;
@@ -78,7 +78,7 @@ void test_limit_is_prime(void)
 
 void test_find_primes_up_to_1000(void)
 {
-
+   TEST_IGNORE();
    const unsigned int limit = 1000;
    const primes_array_t expected_prime_array = {
       2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,

--- a/exercises/sieve/test/test_sieve.c
+++ b/exercises/sieve/test/test_sieve.c
@@ -38,7 +38,7 @@ void test_find_first_prime(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
+                    ARRAY_LENGTH(expected_prime_array));
 
 }
 
@@ -55,7 +55,7 @@ void test_find_primes_up_to_10(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
+                    ARRAY_LENGTH(expected_prime_array));
 
 }
 
@@ -72,7 +72,7 @@ void test_limit_is_prime(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
+                    ARRAY_LENGTH(expected_prime_array));
 
 }
 
@@ -103,7 +103,7 @@ void test_find_primes_up_to_1000(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
+                    ARRAY_LENGTH(expected_prime_array));
 
 }
 

--- a/exercises/sieve/test/test_sieve.c
+++ b/exercises/sieve/test/test_sieve.c
@@ -38,7 +38,7 @@ void test_find_first_prime(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                    ARRAY_LENGTH(expected_prime_array));
+                                ARRAY_LENGTH(expected_prime_array));
 
 }
 
@@ -55,7 +55,7 @@ void test_find_primes_up_to_10(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                    ARRAY_LENGTH(expected_prime_array));
+                                ARRAY_LENGTH(expected_prime_array));
 
 }
 
@@ -72,7 +72,7 @@ void test_limit_is_prime(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                    ARRAY_LENGTH(expected_prime_array));
+                                ARRAY_LENGTH(expected_prime_array));
 
 }
 
@@ -103,7 +103,7 @@ void test_find_primes_up_to_1000(void)
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                    ARRAY_LENGTH(expected_prime_array));
+                                ARRAY_LENGTH(expected_prime_array));
 
 }
 

--- a/exercises/sieve/test/test_sieve.c
+++ b/exercises/sieve/test/test_sieve.c
@@ -3,6 +3,7 @@
 #include "../src/sieve.h"
 
 static primes_array_t result_array;
+#define ARRAY_LENGTH(x)   sizeof(x)/sizeof(x[0])
 
 void setUp(void)
 {
@@ -15,7 +16,6 @@ void tearDown(void)
 void test_no_primes_under_two(void)
 {
    const unsigned int limit = 1;
-   const primes_array_t expected_prime_array = { 0 };
    const unsigned int expected_prime_count = 0;
    unsigned int result_prime_count;
 
@@ -23,14 +23,11 @@ void test_no_primes_under_two(void)
 
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
-   TEST_ASSERT_EQUAL(0,
-                     memcmp(expected_prime_array, result_array,
-                            sizeof(result_array)));
 }
 
 void test_find_first_prime(void)
 {
-   TEST_IGNORE();               // delete this line to run test
+   // delete this line to run test
    const unsigned int limit = 2;
    const primes_array_t expected_prime_array = { 2 };
    const unsigned int expected_prime_count = 1;
@@ -40,14 +37,14 @@ void test_find_first_prime(void)
 
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
-   TEST_ASSERT_EQUAL(0,
-                     memcmp(expected_prime_array, result_array,
-                            sizeof(expected_prime_array)));
+   TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
+                                ARRAY_LENGTH(expected_prime_array));
+
 }
 
 void test_find_primes_up_to_10(void)
 {
-   TEST_IGNORE();
+
    const unsigned int limit = 10;
    const primes_array_t expected_prime_array = { 2, 3, 5, 7 };
    const unsigned int expected_prime_count = 4;
@@ -57,14 +54,14 @@ void test_find_primes_up_to_10(void)
 
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
-   TEST_ASSERT_EQUAL(0,
-                     memcmp(expected_prime_array, result_array,
-                            sizeof(expected_prime_array)));
+   TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
+                                ARRAY_LENGTH(expected_prime_array));
+
 }
 
 void test_limit_is_prime(void)
 {
-   TEST_IGNORE();
+
    const unsigned int limit = 13;
    const primes_array_t expected_prime_array = { 2, 3, 5, 7, 11, 13 };
    const unsigned int expected_prime_count = 6;
@@ -74,14 +71,14 @@ void test_limit_is_prime(void)
 
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
-   TEST_ASSERT_EQUAL(0,
-                     memcmp(expected_prime_array, result_array,
-                            sizeof(expected_prime_array)));
+   TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
+                                ARRAY_LENGTH(expected_prime_array));
+
 }
 
 void test_find_primes_up_to_1000(void)
 {
-   TEST_IGNORE();
+
    const unsigned int limit = 1000;
    const primes_array_t expected_prime_array = {
       2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
@@ -105,9 +102,9 @@ void test_find_primes_up_to_1000(void)
 
    result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
-   TEST_ASSERT_EQUAL(0,
-                     memcmp(expected_prime_array, result_array,
-                            sizeof(expected_prime_array)));
+   TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
+                                ARRAY_LENGTH(expected_prime_array));
+
 }
 
 int main(void)


### PR DESCRIPTION
Updated test to use the Unity macro.  Provides a better error message.  Checked for other test suites using memcmp, but there were none.