### PR TITLE
Remove *.dSYM folders in 'clean' rule

### DIFF
--- a/exercises/acronym/makefile
+++ b/exercises/acronym/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_acronym.c src/acronym.c src/acronym.h
 	@echo Compiling $@

--- a/exercises/all-your-base/makefile
+++ b/exercises/all-your-base/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_all_your_base.c src/all_your_base.c src/all_your_base.h
 	@echo Compiling $@

--- a/exercises/allergies/makefile
+++ b/exercises/allergies/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_allergies.c src/allergies.c src/allergies.h
 	@echo Compiling $@

--- a/exercises/anagram/makefile
+++ b/exercises/anagram/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_anagram.c src/anagram.c src/anagram.h
 	@echo Compiling $@

--- a/exercises/atbash-cipher/makefile
+++ b/exercises/atbash-cipher/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_atbash_cipher.c src/atbash_cipher.c src/atbash_cipher.h
 	@echo Compiling $@

--- a/exercises/beer-song/makefile
+++ b/exercises/beer-song/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_beer_song.c src/beer_song.c src/beer_song.h
 	@echo Compiling $@

--- a/exercises/binary-search/makefile
+++ b/exercises/binary-search/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_binary_search.c src/binary_search.c src/binary_search.h
 	@echo Compiling $@

--- a/exercises/binary/makefile
+++ b/exercises/binary/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_binary.c src/binary.c src/binary.h
 	@echo Compiling $@

--- a/exercises/bob/makefile
+++ b/exercises/bob/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_bob.c src/bob.c src/bob.h
 	@echo Compiling $@

--- a/exercises/clock/makefile
+++ b/exercises/clock/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_clock.c src/clock.c src/clock.h
 	@echo Compiling $@

--- a/exercises/collatz-conjecture/makefile
+++ b/exercises/collatz-conjecture/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_collatz_conjecture.c src/collatz_conjecture.c src/collatz_conjecture.h
 	@echo Compiling $@

--- a/exercises/difference-of-squares/makefile
+++ b/exercises/difference-of-squares/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_difference_of_squares.c src/difference_of_squares.c src/difference_of_squares.h
 	@echo Compiling $@

--- a/exercises/gigasecond/makefile
+++ b/exercises/gigasecond/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_gigasecond.c src/gigasecond.c src/gigasecond.h
 	@echo Compiling $@

--- a/exercises/grains/makefile
+++ b/exercises/grains/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_grains.c src/grains.c src/grains.h
 	@echo Compiling $@

--- a/exercises/hamming/makefile
+++ b/exercises/hamming/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_hamming.c src/hamming.c src/hamming.h
 	@echo Compiling $@

--- a/exercises/hello-world/makefile
+++ b/exercises/hello-world/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_hello_world.c src/hello_world.c src/hello_world.h
 	@echo Compiling $@

--- a/exercises/isogram/makefile
+++ b/exercises/isogram/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_isogram.c src/isogram.c src/isogram.h
 	@echo Compiling $@

--- a/exercises/largest-series-product/makefile
+++ b/exercises/largest-series-product/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_largest_series_product.c src/largest_series_product.c src/largest_series_product.h
 	@echo Compiling $@

--- a/exercises/leap/makefile
+++ b/exercises/leap/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_leap.c src/leap.c src/leap.h
 	@echo Compiling $@

--- a/exercises/meetup/makefile
+++ b/exercises/meetup/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_meetup.c src/meetup.c src/meetup.h
 	@echo Compiling $@

--- a/exercises/nth-prime/makefile
+++ b/exercises/nth-prime/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_nth_prime.c src/nth_prime.c src/nth_prime.h
 	@echo Compiling $@

--- a/exercises/nucleotide-count/makefile
+++ b/exercises/nucleotide-count/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: src/nucleotide_count.c src/nucleotide_count.h test/test_nucleotide_count.c 
 	@echo Compiling $@

--- a/exercises/palindrome-products/makefile
+++ b/exercises/palindrome-products/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_palindrome_products.c src/palindrome_products.c src/palindrome_products.h
 	@echo Compiling $@

--- a/exercises/pangram/makefile
+++ b/exercises/pangram/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_pangram.c src/pangram.c src/pangram.h
 	@echo Compiling $@

--- a/exercises/pascals-triangle/makefile
+++ b/exercises/pascals-triangle/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_pascals_triangle.c src/pascals_triangle.c src/pascals_triangle.h
 	@echo Compiling $@

--- a/exercises/perfect-numbers/makefile
+++ b/exercises/perfect-numbers/makefile
@@ -17,7 +17,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_perfect_numbers.c src/perfect_numbers.c src/perfect_numbers.h
 	@echo Compiling $@

--- a/exercises/phone-number/makefile
+++ b/exercises/phone-number/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_phone_number.c src/phone_number.c src/phone_number.h
 	@echo Compiling $@

--- a/exercises/queen-attack/makefile
+++ b/exercises/queen-attack/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_queen_attack.c src/queen_attack.c src/queen_attack.h
 	@echo Compiling $@

--- a/exercises/raindrops/makefile
+++ b/exercises/raindrops/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_raindrops.c src/raindrops.c src/raindrops.h
 	@echo Compiling $@

--- a/exercises/react/makefile
+++ b/exercises/react/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_react.c src/react.c src/react.h
 	@echo Compiling $@

--- a/exercises/rna-transcription/makefile
+++ b/exercises/rna-transcription/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_rna_transcription.c src/rna_transcription.c src/rna_transcription.h
 	@echo Compiling $@

--- a/exercises/robot-simulator/makefile
+++ b/exercises/robot-simulator/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_robot_simulator.c src/robot_simulator.c src/robot_simulator.h
 	@echo Compiling $@

--- a/exercises/roman-numerals/makefile
+++ b/exercises/roman-numerals/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_roman_numerals.c src/roman_numerals.c src/roman_numerals.h
 	@echo Compiling $@

--- a/exercises/scrabble-score/makefile
+++ b/exercises/scrabble-score/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_scrabble_score.c src/scrabble_score.c src/scrabble_score.h
 	@echo Compiling $@

--- a/exercises/series/makefile
+++ b/exercises/series/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_series.c src/series.c src/series.h
 	@echo Compiling $@

--- a/exercises/sieve/makefile
+++ b/exercises/sieve/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_sieve.c src/sieve.c src/sieve.h
 	@echo Compiling $@

--- a/exercises/space-age/makefile
+++ b/exercises/space-age/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_space_age.c src/space_age.c src/space_age.h
 	@echo Compiling $@

--- a/exercises/sublist/makefile
+++ b/exercises/sublist/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_sublist.c src/sublist.c src/sublist.h
 	@echo Compiling $@

--- a/exercises/sum-of-multiples/makefile
+++ b/exercises/sum-of-multiples/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_sum_of_multiples.c src/sum_of_multiples.c src/sum_of_multiples.h
 	@echo Compiling $@

--- a/exercises/triangle/makefile
+++ b/exercises/triangle/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_triangle.c src/triangle.c src/triangle.h
 	@echo Compiling $@

--- a/exercises/word-count/makefile
+++ b/exercises/word-count/makefile
@@ -18,7 +18,7 @@ memcheck: tests.out
 	@echo "Memory check passed"
 
 clean:
-	rm -f *.o *.out
+	rm -rf *.o *.out *.out.dSYM
 
 tests.out: test/test_word_count.c src/word_count.c src/word_count.h
 	@echo Compiling $@


### PR DESCRIPTION
On macOS (using the Xcode compiler), compiling with debug symbols (`-g`) causes the creation of a _*.dSYM_ folder, e.g., _test.out.dSYM_.

This PR adds these folders to the makefile `clean` rules.