### PR TITLE
bob: Lock problem description to match current implementation

### DIFF
--- a/exercises/bob/.meta/description.md
+++ b/exercises/bob/.meta/description.md
@@ -1,0 +1,10 @@
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.


### PR DESCRIPTION
We need to be able to regenerate the exercise READMEs without
causing the README for 'bob' to drift.

A new rule has been added to the upstream problem specification,
and this hasn't yet been implemented in this track.

I only realized after submitting https://github.com/exercism/c/issues/264 that I needed to regenerate the exercise READMEs in order to move forward with https://github.com/exercism/meta/issues/94, which would cause 'bob' to get out of sync.

Since this is a purely janitorial change, I am going to go ahead and merge it when the build passes.

I'm adding a note to the ambiguity issue about deleting this file when the test suite gets updated.