### PR TITLE
Use the CC implicit variable in exercise makefiles

### DIFF
--- a/exercises/acronym/makefile
+++ b/exercises/acronym/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_acronym.c src/acronym.c src/acronym.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/acronym.c test/vendor/unity.c test/test_acronym.c -o tests.out
+	@$(CC) $(CFLAGS) src/acronym.c test/vendor/unity.c test/test_acronym.c -o tests.out

--- a/exercises/all-your-base/makefile
+++ b/exercises/all-your-base/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_all_your_base.c src/all_your_base.c src/all_your_base.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/all_your_base.c test/vendor/unity.c test/test_all_your_base.c -o tests.out -lm
+	@$(CC) $(CFLAGS) src/all_your_base.c test/vendor/unity.c test/test_all_your_base.c -o tests.out -lm

--- a/exercises/allergies/makefile
+++ b/exercises/allergies/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_allergies.c src/allergies.c src/allergies.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/allergies.c test/vendor/unity.c test/test_allergies.c -o tests.out
+	@$(CC) $(CFLAGS) src/allergies.c test/vendor/unity.c test/test_allergies.c -o tests.out

--- a/exercises/anagram/makefile
+++ b/exercises/anagram/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_anagram.c src/anagram.c src/anagram.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/anagram.c test/vendor/unity.c test/test_anagram.c -o tests.out
+	@$(CC) $(CFLAGS) src/anagram.c test/vendor/unity.c test/test_anagram.c -o tests.out

--- a/exercises/atbash-cipher/makefile
+++ b/exercises/atbash-cipher/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_atbash_cipher.c src/atbash_cipher.c src/atbash_cipher.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/atbash_cipher.c test/vendor/unity.c test/test_atbash_cipher.c -o tests.out
+	@$(CC) $(CFLAGS) src/atbash_cipher.c test/vendor/unity.c test/test_atbash_cipher.c -o tests.out

--- a/exercises/beer-song/makefile
+++ b/exercises/beer-song/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_beer_song.c src/beer_song.c src/beer_song.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/beer_song.c test/vendor/unity.c test/test_beer_song.c -o tests.out
+	@$(CC) $(CFLAGS) src/beer_song.c test/vendor/unity.c test/test_beer_song.c -o tests.out

--- a/exercises/binary-search-tree/makefile
+++ b/exercises/binary-search-tree/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_binary_search_tree.c src/binary_search_tree.c src/binary_search_tree.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/binary_search_tree.c test/vendor/unity.c test/test_binary_search_tree.c -o tests.out
+	@$(CC) $(CFLAGS) src/binary_search_tree.c test/vendor/unity.c test/test_binary_search_tree.c -o tests.out

--- a/exercises/binary-search/makefile
+++ b/exercises/binary-search/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_binary_search.c src/binary_search.c src/binary_search.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/binary_search.c test/vendor/unity.c test/test_binary_search.c -o tests.out
+	@$(CC) $(CFLAGS) src/binary_search.c test/vendor/unity.c test/test_binary_search.c -o tests.out

--- a/exercises/binary/makefile
+++ b/exercises/binary/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_binary.c src/binary.c src/binary.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/binary.c test/vendor/unity.c test/test_binary.c -o tests.out
+	@$(CC) $(CFLAGS) src/binary.c test/vendor/unity.c test/test_binary.c -o tests.out

--- a/exercises/bob/makefile
+++ b/exercises/bob/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_bob.c src/bob.c src/bob.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/bob.c test/vendor/unity.c test/test_bob.c -o tests.out
+	@$(CC) $(CFLAGS) src/bob.c test/vendor/unity.c test/test_bob.c -o tests.out

--- a/exercises/bracket-push/makefile
+++ b/exercises/bracket-push/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_bracket_push.c src/bracket_push.c src/bracket_push.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/bracket_push.c test/vendor/unity.c test/test_bracket_push.c -o tests.out
+	@$(CC) $(CFLAGS) src/bracket_push.c test/vendor/unity.c test/test_bracket_push.c -o tests.out

--- a/exercises/clock/makefile
+++ b/exercises/clock/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_clock.c src/clock.c src/clock.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/clock.c test/vendor/unity.c test/test_clock.c -o tests.out
+	@$(CC) $(CFLAGS) src/clock.c test/vendor/unity.c test/test_clock.c -o tests.out

--- a/exercises/collatz-conjecture/makefile
+++ b/exercises/collatz-conjecture/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_collatz_conjecture.c src/collatz_conjecture.c src/collatz_conjecture.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/collatz_conjecture.c test/vendor/unity.c test/test_collatz_conjecture.c -o tests.out
+	@$(CC) $(CFLAGS) src/collatz_conjecture.c test/vendor/unity.c test/test_collatz_conjecture.c -o tests.out

--- a/exercises/complex-numbers/makefile
+++ b/exercises/complex-numbers/makefile
@@ -24,4 +24,4 @@ clean:
 
 tests.out: test/test_complex_numbers.c src/complex_numbers.c src/complex_numbers.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/complex_numbers.c test/vendor/unity.c test/test_complex_numbers.c $(LDFLAGS) -o tests.out
+	@$(CC) $(CFLAGS) src/complex_numbers.c test/vendor/unity.c test/test_complex_numbers.c $(LDFLAGS) -o tests.out

--- a/exercises/crypto-square/makefile
+++ b/exercises/crypto-square/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_crypto_square.c src/crypto_square.c src/crypto_square.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/crypto_square.c test/vendor/unity.c test/test_crypto_square.c -o tests.out -lm
+	@$(CC) $(CFLAGS) src/crypto_square.c test/vendor/unity.c test/test_crypto_square.c -o tests.out -lm

--- a/exercises/diamond/makefile
+++ b/exercises/diamond/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_diamond.c src/diamond.c src/diamond.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/diamond.c test/vendor/unity.c test/test_diamond.c -o tests.out
+	@$(CC) $(CFLAGS) src/diamond.c test/vendor/unity.c test/test_diamond.c -o tests.out

--- a/exercises/difference-of-squares/makefile
+++ b/exercises/difference-of-squares/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_difference_of_squares.c src/difference_of_squares.c src/difference_of_squares.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/difference_of_squares.c test/vendor/unity.c test/test_difference_of_squares.c -o tests.out
+	@$(CC) $(CFLAGS) src/difference_of_squares.c test/vendor/unity.c test/test_difference_of_squares.c -o tests.out

--- a/exercises/etl/makefile
+++ b/exercises/etl/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_etl.c src/etl.c src/etl.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/etl.c test/vendor/unity.c test/test_etl.c -o tests.out
+	@$(CC) $(CFLAGS) src/etl.c test/vendor/unity.c test/test_etl.c -o tests.out

--- a/exercises/gigasecond/makefile
+++ b/exercises/gigasecond/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_gigasecond.c src/gigasecond.c src/gigasecond.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/gigasecond.c test/vendor/unity.c test/test_gigasecond.c -o tests.out
+	@$(CC) $(CFLAGS) src/gigasecond.c test/vendor/unity.c test/test_gigasecond.c -o tests.out

--- a/exercises/grains/makefile
+++ b/exercises/grains/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_grains.c src/grains.c src/grains.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/grains.c test/vendor/unity.c test/test_grains.c -o tests.out
+	@$(CC) $(CFLAGS) src/grains.c test/vendor/unity.c test/test_grains.c -o tests.out

--- a/exercises/hamming/makefile
+++ b/exercises/hamming/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_hamming.c src/hamming.c src/hamming.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/hamming.c test/vendor/unity.c test/test_hamming.c -o tests.out
+	@$(CC) $(CFLAGS) src/hamming.c test/vendor/unity.c test/test_hamming.c -o tests.out

--- a/exercises/hello-world/makefile
+++ b/exercises/hello-world/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_hello_world.c src/hello_world.c src/hello_world.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/hello_world.c test/vendor/unity.c test/test_hello_world.c -o tests.out
+	@$(CC) $(CFLAGS) src/hello_world.c test/vendor/unity.c test/test_hello_world.c -o tests.out

--- a/exercises/isogram/makefile
+++ b/exercises/isogram/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_isogram.c src/isogram.c src/isogram.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/isogram.c test/vendor/unity.c test/test_isogram.c -o tests.out
+	@$(CC) $(CFLAGS) src/isogram.c test/vendor/unity.c test/test_isogram.c -o tests.out

--- a/exercises/largest-series-product/makefile
+++ b/exercises/largest-series-product/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_largest_series_product.c src/largest_series_product.c src/largest_series_product.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/largest_series_product.c test/vendor/unity.c test/test_largest_series_product.c -o tests.out
+	@$(CC) $(CFLAGS) src/largest_series_product.c test/vendor/unity.c test/test_largest_series_product.c -o tests.out

--- a/exercises/leap/makefile
+++ b/exercises/leap/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_leap.c src/leap.c src/leap.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/leap.c test/vendor/unity.c test/test_leap.c -o tests.out
+	@$(CC) $(CFLAGS) src/leap.c test/vendor/unity.c test/test_leap.c -o tests.out

--- a/exercises/luhn/makefile
+++ b/exercises/luhn/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_luhn.c src/luhn.c src/luhn.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/luhn.c test/vendor/unity.c test/test_luhn.c -o tests.out
+	@$(CC) $(CFLAGS) src/luhn.c test/vendor/unity.c test/test_luhn.c -o tests.out

--- a/exercises/meetup/makefile
+++ b/exercises/meetup/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_meetup.c src/meetup.c src/meetup.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/meetup.c test/vendor/unity.c test/test_meetup.c -o tests.out
+	@$(CC) $(CFLAGS) src/meetup.c test/vendor/unity.c test/test_meetup.c -o tests.out

--- a/exercises/minesweeper/makefile
+++ b/exercises/minesweeper/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_minesweeper.c src/minesweeper.c src/minesweeper.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/minesweeper.c test/vendor/unity.c test/test_minesweeper.c -o tests.out
+	@$(CC) $(CFLAGS) src/minesweeper.c test/vendor/unity.c test/test_minesweeper.c -o tests.out

--- a/exercises/nth-prime/makefile
+++ b/exercises/nth-prime/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_nth_prime.c src/nth_prime.c src/nth_prime.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/nth_prime.c test/vendor/unity.c test/test_nth_prime.c -o tests.out
+	@$(CC) $(CFLAGS) src/nth_prime.c test/vendor/unity.c test/test_nth_prime.c -o tests.out

--- a/exercises/nucleotide-count/makefile
+++ b/exercises/nucleotide-count/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: src/nucleotide_count.c src/nucleotide_count.h test/test_nucleotide_count.c 
 	@echo Compiling $@
-	@cc $(CFLAGS) src/nucleotide_count.c test/vendor/unity.c test/test_nucleotide_count.c -o tests.out
+	@$(CC) $(CFLAGS) src/nucleotide_count.c test/vendor/unity.c test/test_nucleotide_count.c -o tests.out

--- a/exercises/palindrome-products/makefile
+++ b/exercises/palindrome-products/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_palindrome_products.c src/palindrome_products.c src/palindrome_products.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/palindrome_products.c test/vendor/unity.c test/test_palindrome_products.c -o tests.out
+	@$(CC) $(CFLAGS) src/palindrome_products.c test/vendor/unity.c test/test_palindrome_products.c -o tests.out

--- a/exercises/pangram/makefile
+++ b/exercises/pangram/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_pangram.c src/pangram.c src/pangram.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/pangram.c test/vendor/unity.c test/test_pangram.c -o tests.out
+	@$(CC) $(CFLAGS) src/pangram.c test/vendor/unity.c test/test_pangram.c -o tests.out

--- a/exercises/pascals-triangle/makefile
+++ b/exercises/pascals-triangle/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_pascals_triangle.c src/pascals_triangle.c src/pascals_triangle.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/pascals_triangle.c test/vendor/unity.c test/test_pascals_triangle.c -o tests.out
+	@$(CC) $(CFLAGS) src/pascals_triangle.c test/vendor/unity.c test/test_pascals_triangle.c -o tests.out

--- a/exercises/perfect-numbers/makefile
+++ b/exercises/perfect-numbers/makefile
@@ -21,4 +21,4 @@ clean:
 
 tests.out: test/test_perfect_numbers.c src/perfect_numbers.c src/perfect_numbers.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/perfect_numbers.c test/vendor/unity.c test/test_perfect_numbers.c -o tests.out
+	@$(CC) $(CFLAGS) src/perfect_numbers.c test/vendor/unity.c test/test_perfect_numbers.c -o tests.out

--- a/exercises/phone-number/makefile
+++ b/exercises/phone-number/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_phone_number.c src/phone_number.c src/phone_number.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/phone_number.c test/vendor/unity.c test/test_phone_number.c -o tests.out
+	@$(CC) $(CFLAGS) src/phone_number.c test/vendor/unity.c test/test_phone_number.c -o tests.out

--- a/exercises/pig-latin/makefile
+++ b/exercises/pig-latin/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_pig_latin.c src/pig_latin.c src/pig_latin.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/pig_latin.c test/vendor/unity.c test/test_pig_latin.c -o tests.out
+	@$(CC) $(CFLAGS) src/pig_latin.c test/vendor/unity.c test/test_pig_latin.c -o tests.out

--- a/exercises/prime-factors/makefile
+++ b/exercises/prime-factors/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_prime_factors.c src/prime_factors.c src/prime_factors.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/prime_factors.c test/vendor/unity.c test/test_prime_factors.c -o tests.out -lm
+	@$(CC) $(CFLAGS) src/prime_factors.c test/vendor/unity.c test/test_prime_factors.c -o tests.out -lm

--- a/exercises/queen-attack/makefile
+++ b/exercises/queen-attack/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_queen_attack.c src/queen_attack.c src/queen_attack.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/queen_attack.c test/vendor/unity.c test/test_queen_attack.c -o tests.out
+	@$(CC) $(CFLAGS) src/queen_attack.c test/vendor/unity.c test/test_queen_attack.c -o tests.out

--- a/exercises/raindrops/makefile
+++ b/exercises/raindrops/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_raindrops.c src/raindrops.c src/raindrops.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/raindrops.c test/vendor/unity.c test/test_raindrops.c -o tests.out
+	@$(CC) $(CFLAGS) src/raindrops.c test/vendor/unity.c test/test_raindrops.c -o tests.out

--- a/exercises/react/makefile
+++ b/exercises/react/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_react.c src/react.c src/react.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/react.c test/vendor/unity.c test/test_react.c -o tests.out
+	@$(CC) $(CFLAGS) src/react.c test/vendor/unity.c test/test_react.c -o tests.out

--- a/exercises/rna-transcription/makefile
+++ b/exercises/rna-transcription/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_rna_transcription.c src/rna_transcription.c src/rna_transcription.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/rna_transcription.c test/vendor/unity.c test/test_rna_transcription.c -o tests.out
+	@$(CC) $(CFLAGS) src/rna_transcription.c test/vendor/unity.c test/test_rna_transcription.c -o tests.out

--- a/exercises/robot-simulator/makefile
+++ b/exercises/robot-simulator/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_robot_simulator.c src/robot_simulator.c src/robot_simulator.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/robot_simulator.c test/vendor/unity.c test/test_robot_simulator.c -o tests.out
+	@$(CC) $(CFLAGS) src/robot_simulator.c test/vendor/unity.c test/test_robot_simulator.c -o tests.out

--- a/exercises/roman-numerals/makefile
+++ b/exercises/roman-numerals/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_roman_numerals.c src/roman_numerals.c src/roman_numerals.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/roman_numerals.c test/vendor/unity.c test/test_roman_numerals.c -o tests.out
+	@$(CC) $(CFLAGS) src/roman_numerals.c test/vendor/unity.c test/test_roman_numerals.c -o tests.out

--- a/exercises/run-length-encoding/makefile
+++ b/exercises/run-length-encoding/makefile
@@ -24,4 +24,4 @@ clean:
 
 tests.out: test/test_run_length_encoding.c src/run_length_encoding.c src/run_length_encoding.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/run_length_encoding.c test/vendor/unity.c test/test_run_length_encoding.c -o tests.out $(LDFLAGS)
+	@$(CC) $(CFLAGS) src/run_length_encoding.c test/vendor/unity.c test/test_run_length_encoding.c -o tests.out $(LDFLAGS)

--- a/exercises/say/makefile
+++ b/exercises/say/makefile
@@ -24,4 +24,4 @@ clean:
 
 tests.out: test/test_say.c src/say.c src/say.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/say.c test/vendor/unity.c test/test_say.c -o tests.out $(LDFLAGS)
+	@$(CC) $(CFLAGS) src/say.c test/vendor/unity.c test/test_say.c -o tests.out $(LDFLAGS)

--- a/exercises/scrabble-score/makefile
+++ b/exercises/scrabble-score/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_scrabble_score.c src/scrabble_score.c src/scrabble_score.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/scrabble_score.c test/vendor/unity.c test/test_scrabble_score.c -o tests.out
+	@$(CC) $(CFLAGS) src/scrabble_score.c test/vendor/unity.c test/test_scrabble_score.c -o tests.out

--- a/exercises/secret-handshake/makefile
+++ b/exercises/secret-handshake/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_secret_handshake.c src/secret_handshake.c src/secret_handshake.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/secret_handshake.c test/vendor/unity.c test/test_secret_handshake.c -o tests.out
+	@$(CC) $(CFLAGS) src/secret_handshake.c test/vendor/unity.c test/test_secret_handshake.c -o tests.out

--- a/exercises/series/makefile
+++ b/exercises/series/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_series.c src/series.c src/series.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/series.c test/vendor/unity.c test/test_series.c -o tests.out
+	@$(CC) $(CFLAGS) src/series.c test/vendor/unity.c test/test_series.c -o tests.out

--- a/exercises/sieve/makefile
+++ b/exercises/sieve/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_sieve.c src/sieve.c src/sieve.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/sieve.c test/vendor/unity.c test/test_sieve.c -o tests.out -lm
+	@$(CC) $(CFLAGS) src/sieve.c test/vendor/unity.c test/test_sieve.c -o tests.out -lm

--- a/exercises/space-age/makefile
+++ b/exercises/space-age/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_space_age.c src/space_age.c src/space_age.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/space_age.c test/vendor/unity.c test/test_space_age.c -o tests.out
+	@$(CC) $(CFLAGS) src/space_age.c test/vendor/unity.c test/test_space_age.c -o tests.out

--- a/exercises/sublist/makefile
+++ b/exercises/sublist/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_sublist.c src/sublist.c src/sublist.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/sublist.c test/vendor/unity.c test/test_sublist.c -o tests.out
+	@$(CC) $(CFLAGS) src/sublist.c test/vendor/unity.c test/test_sublist.c -o tests.out

--- a/exercises/sum-of-multiples/makefile
+++ b/exercises/sum-of-multiples/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_sum_of_multiples.c src/sum_of_multiples.c src/sum_of_multiples.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/sum_of_multiples.c test/vendor/unity.c test/test_sum_of_multiples.c -o tests.out
+	@$(CC) $(CFLAGS) src/sum_of_multiples.c test/vendor/unity.c test/test_sum_of_multiples.c -o tests.out

--- a/exercises/triangle/makefile
+++ b/exercises/triangle/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_triangle.c src/triangle.c src/triangle.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/triangle.c test/vendor/unity.c test/test_triangle.c -o tests.out
+	@$(CC) $(CFLAGS) src/triangle.c test/vendor/unity.c test/test_triangle.c -o tests.out

--- a/exercises/two-fer/makefile
+++ b/exercises/two-fer/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_two_fer.c src/two_fer.c src/two_fer.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/two_fer.c test/vendor/unity.c test/test_two_fer.c -o tests.out
+	@$(CC) $(CFLAGS) src/two_fer.c test/vendor/unity.c test/test_two_fer.c -o tests.out

--- a/exercises/word-count/makefile
+++ b/exercises/word-count/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_word_count.c src/word_count.c src/word_count.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/word_count.c test/vendor/unity.c test/test_word_count.c -o tests.out
+	@$(CC) $(CFLAGS) src/word_count.c test/vendor/unity.c test/test_word_count.c -o tests.out

--- a/exercises/wordy/makefile
+++ b/exercises/wordy/makefile
@@ -22,4 +22,4 @@ clean:
 
 tests.out: test/test_wordy.c src/wordy.c src/wordy.h
 	@echo Compiling $@
-	@cc $(CFLAGS) src/wordy.c test/vendor/unity.c test/test_wordy.c -o tests.out
+	@$(CC) $(CFLAGS) src/wordy.c test/vendor/unity.c test/test_wordy.c -o tests.out


### PR DESCRIPTION
This would make it slightly more convenient to override the compiler used.  For example `make CC=clang` vs. having to edit the makefile or having to ensure that the `cc` in the environment is the compiler you want to use.