### PR TITLE
Added test for duplicated letter past 'h'.

### DIFF
--- a/exercises/isogram/test/test_isogram.c
+++ b/exercises/isogram/test/test_isogram.c
@@ -27,6 +27,12 @@ void test_duplicated_letter(void)
    TEST_ASSERT_FALSE(is_isogram("eleven"));
 }
 
+void test_duplicated_letter_from_end_of_alphabet(void)
+{
+   TEST_IGNORE();
+   TEST_ASSERT_FALSE(is_isogram("zzyzx"));
+}
+
 void test_longest_known_isogram(void)
 {
    TEST_IGNORE();
@@ -70,6 +76,7 @@ int main(void)
    RUN_TEST(test_empty_string);
    RUN_TEST(test_lower_case_only);
    RUN_TEST(test_duplicated_letter);
+   RUN_TEST(test_duplicated_letter_from_end_of_alphabet);
    RUN_TEST(test_longest_known_isogram);
    RUN_TEST(test_duplicated_letter_mixed_case);
    RUN_TEST(test_non_letter_char);


### PR DESCRIPTION
In the current test set, a submission will pass if it only checks for
duplicates in the first 8 letters.