### PR TITLE
Fix complex tests by configuring Unity to use doubles instead of floats

### DIFF
--- a/exercises/complex-numbers/makefile
+++ b/exercises/complex-numbers/makefile
@@ -4,6 +4,7 @@ CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
+CFLAGS += -DUNITY_FLOAT_TYPE=double
 
 VFLAGS  = --quiet
 VFLAGS += --tool=memcheck

--- a/exercises/complex-numbers/src/example.c
+++ b/exercises/complex-numbers/src/example.c
@@ -38,7 +38,7 @@ complex_t c_div(const complex_t a, const complex_t b)
    double denominator = square(b.real) + square(b.imag);
 
    complex_t result;
-   result.real = (a.real * b.imag + a.imag * b.real) / denominator;
+   result.real = (a.real * b.real + a.imag * b.imag) / denominator;
    result.imag = (a.imag * b.real - a.real * b.imag) / denominator;
 
    return result;

--- a/exercises/complex-numbers/test/test_complex_numbers.c
+++ b/exercises/complex-numbers/test/test_complex_numbers.c
@@ -27,7 +27,6 @@ void test_imaginary_unit(void)
 void test_add_purely_real_numbers(void)
 {
    TEST_IGNORE();
-
    complex_t z1 = {.real = 1.0,.imag = 0.0 };
    complex_t z2 = {.real = 2.0,.imag = 0.0 };
 
@@ -368,11 +367,11 @@ int main(void)
    RUN_TEST(test_subtract_purely_real_numbers);
    RUN_TEST(test_subtract_purely_imaginary_numbers);
    RUN_TEST(test_subtract_numbers_with_real_and_imaginary_part);
+   RUN_TEST(test_multiply_purely_real_numbers);
+   RUN_TEST(test_multiply_purely_imaginary_numbers);
    RUN_TEST(test_multiply_numbers_with_real_and_imaginary_part);
-   RUN_TEST(test_multiply_numbers_with_real_and_imaginary_part);
-   RUN_TEST(test_multiply_numbers_with_real_and_imaginary_part);
-   RUN_TEST(test_divide_numbers_with_real_and_imaginary_part);
-   RUN_TEST(test_divide_numbers_with_real_and_imaginary_part);
+   RUN_TEST(test_divide_purely_real_numbers);
+   RUN_TEST(test_divide_purely_imaginary_numbers);
    RUN_TEST(test_divide_numbers_with_real_and_imaginary_part);
    RUN_TEST(test_abs_of_a_positive_purely_real_number);
    RUN_TEST(test_abs_of_a_negative_purely_real_number);


### PR DESCRIPTION
Fixes #326 

Turns out that Unity uses `float`s by default, but the complex numbers exercise uses `double`s. This results in false negatives for all checks that use floating point numbers. After configuring Unity properly, I verified that incorrect implementations are correctly flagged. In fact, this reveals errors in the sample implementation that still need to be fixed.

Thanks @Zialus for finding this issue!