### PR TITLE
acronym: Added test for long abbreviation

### DIFF
--- a/exercises/acronym/test/test_acronym.c
+++ b/exercises/acronym/test/test_acronym.c
@@ -93,7 +93,8 @@ void test_all_words_starting_with_lowercase(void)
 void test_long_abbreviation(void)
 {
    TEST_IGNORE();
-   char *phrase = "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me";
+   char *phrase = "Rolling On The Floor Laughing So Hard "
+       "That My Dogs Came Over And Licked Me";
    char *expected = "ROTFLSHTMDCOALM";
    test_abbreviation(phrase, expected);
 }

--- a/exercises/acronym/test/test_acronym.c
+++ b/exercises/acronym/test/test_acronym.c
@@ -90,6 +90,14 @@ void test_all_words_starting_with_lowercase(void)
    test_abbreviation(phrase, expected);
 }
 
+void test_long_abbreviation(void)
+{
+   TEST_IGNORE();
+   char *phrase = "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me";
+   char *expected = "ROTFLSHTMDCOALM";
+   test_abbreviation(phrase, expected);
+}
+
 int main(void)
 {
    UnityBegin("test/test_acronym.c");
@@ -103,6 +111,7 @@ int main(void)
    RUN_TEST(test_all_caps_words);
    RUN_TEST(test_empty_string);
    RUN_TEST(test_all_words_starting_with_lowercase);
+   RUN_TEST(test_long_abbreviation);
    UnityEnd();
    return 0;
 }


### PR DESCRIPTION
See #320

The issue involves not allocating enough space for the result, so `make test` may succeed, and the problem would only show up in `make memcheck`.
