### PR TITLE
Use generic assertion for u64s

### DIFF
--- a/exercises/grains/test/test_grains.c
+++ b/exercises/grains/test/test_grains.c
@@ -11,61 +11,61 @@ void tearDown(void)
 
 void test_square_1(void)
 {
-   TEST_ASSERT_EQUAL_UINT64(1ul, square(1));
+   TEST_ASSERT(1ul == square(1));
 }
 
 void test_square_2(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   TEST_ASSERT_EQUAL_UINT64(2ul, square(2));
+   TEST_ASSERT(2ul == square(2));
 }
 
 void test_square_3(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(4ul, square(3));
+   TEST_ASSERT(4ul == square(3));
 }
 
 void test_square_4(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(8ul, square(4));
+   TEST_ASSERT(8ul == square(4));
 }
 
 void test_square_16(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(32768ul, square(16));
+   TEST_ASSERT(32768ul == square(16));
 }
 
 void test_square_32(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(2147483648ul, square(32));
+   TEST_ASSERT(2147483648ul == square(32));
 }
 
 void test_square_64(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(9223372036854775808ul, square(64));
+   TEST_ASSERT(9223372036854775808ul == square(64));
 }
 
 void test_square_0_does_not_exist(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(0, square(0));
+   TEST_ASSERT(0 == square(0));
 }
 
 void test_square_greater_than_64_does_not_exist(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(0, square(65));
+   TEST_ASSERT(0 == square(65));
 }
 
 void test_total(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT64(18446744073709551615ul, total());
+   TEST_ASSERT(18446744073709551615ul == total());
 }
 
 int main(void)


### PR DESCRIPTION
Closes #334 

This avoids using `TEST_ASSERT_EQUAL_UINT64` which is problematic on 32-bit systems (for whatever reason). Instead it uses the generic `TEST_ASSERT` which only evaluates a bool.