### PR TITLE
grains: use unsigned long long (64 bit) constants as expected results

### DIFF
--- a/exercises/grains/test/test_grains.c
+++ b/exercises/grains/test/test_grains.c
@@ -11,43 +11,43 @@ void tearDown(void)
 
 void test_square_1(void)
 {
-   TEST_ASSERT(1ul == square(1));
+   TEST_ASSERT(1ull == square(1));
 }
 
 void test_square_2(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   TEST_ASSERT(2ul == square(2));
+   TEST_ASSERT(2ull == square(2));
 }
 
 void test_square_3(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(4ul == square(3));
+   TEST_ASSERT(4ull == square(3));
 }
 
 void test_square_4(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(8ul == square(4));
+   TEST_ASSERT(8ull == square(4));
 }
 
 void test_square_16(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(32768ul == square(16));
+   TEST_ASSERT(32768ull == square(16));
 }
 
 void test_square_32(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(2147483648ul == square(32));
+   TEST_ASSERT(2147483648ull == square(32));
 }
 
 void test_square_64(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(9223372036854775808ul == square(64));
+   TEST_ASSERT(9223372036854775808ull == square(64));
 }
 
 void test_square_0_does_not_exist(void)
@@ -65,7 +65,7 @@ void test_square_greater_than_64_does_not_exist(void)
 void test_total(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(18446744073709551615ul == total());
+   TEST_ASSERT(18446744073709551615ull == total());
 }
 
 int main(void)


### PR DESCRIPTION
see #339 