### PR TITLE
gigasecond: Addresses: 319

### DIFF
--- a/exercises/gigasecond/test/test_gigasecond.c
+++ b/exercises/gigasecond/test/test_gigasecond.c
@@ -1,26 +1,47 @@
 #include "vendor/unity.h"
 #include "../src/gigasecond.h"
 
+static inline size_t is_leap_year(int year)
+{
+   if(year % 400 == 0)
+   return 1;
+   if(year % 100 == 0)
+   return 0;
+   if(year % 4 == 0)
+   return 1;
+   return 0;
+}
+
+static inline time_t days_from_1ad(int year)
+{
+   --year; // The gegorian calander is without a year 0. This is years from 1AD.
+   // Little complex, add a day for all of the leap years
+   // This is a quarter of the days since 0 execpt one in a hundred are lost except 1 in 400 are gained ... simple.
+   return 365 * year + (year / 400) - (year/100) + (year / 4);
+}
+
+time_t construct_date(int year, int month, int day, int hour, int min, int sec)
+{
+   static const time_t seconds_in_day = 86400;  // 60 * 60 * 24
+   static const time_t days[2][12] =
+   {
+       { 0,31,59,90,120,151,181,212,243,273,304,334},
+       { 0,31,60,91,121,152,182,213,244,274,305,335}
+   };
+
+   time_t days_since_epoch = (days_from_1ad(year) - days_from_1ad(1970)) + days[is_leap_year(year)][(month-1)] + (day - 1);
+   time_t result = (seconds_in_day * days_since_epoch) + (60 * ((hour * 60) + min) + sec);
+
+   return result;
+}
+
+
 void setUp(void)
 {
 }
 
 void tearDown(void)
 {
-}
-
-// Constructs a time_t type from the given date settings
-time_t construct_date(int year, int month, int day, int hour, int min, int sec)
-{
-   struct tm date;
-   date.tm_year = year - 1900;
-   date.tm_mon = month - 1;
-   date.tm_mday = day;
-   date.tm_hour = hour;
-   date.tm_min = min;
-   date.tm_sec = sec;
-   date.tm_isdst = 0;
-   return mktime(&date);
 }
 
 void test_date(void)

--- a/exercises/gigasecond/test/test_gigasecond.c
+++ b/exercises/gigasecond/test/test_gigasecond.c
@@ -3,38 +3,39 @@
 
 static inline size_t is_leap_year(int year)
 {
-   if(year % 400 == 0)
-   return 1;
-   if(year % 100 == 0)
-   return 0;
-   if(year % 4 == 0)
-   return 1;
+   if (year % 400 == 0)
+      return 1;
+   if (year % 100 == 0)
+      return 0;
+   if (year % 4 == 0)
+      return 1;
    return 0;
 }
 
 static inline time_t days_from_1ad(int year)
 {
-   --year; // The gegorian calander is without a year 0. This is years from 1AD.
+   --year;                      // The gegorian calander is without a year 0. This is years from 1AD.
    // Little complex, add a day for all of the leap years
    // This is a quarter of the days since 0 execpt one in a hundred are lost except 1 in 400 are gained ... simple.
-   return 365 * year + (year / 400) - (year/100) + (year / 4);
+   return 365 * year + (year / 400) - (year / 100) + (year / 4);
 }
 
 time_t construct_date(int year, int month, int day, int hour, int min, int sec)
 {
    static const time_t seconds_in_day = 86400;  // 60 * 60 * 24
-   static const time_t days[2][12] =
-   {
-       { 0,31,59,90,120,151,181,212,243,273,304,334},
-       { 0,31,60,91,121,152,182,213,244,274,305,335}
+   static const time_t days[2][12] = {
+      {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
+      {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}
    };
 
-   time_t days_since_epoch = (days_from_1ad(year) - days_from_1ad(1970)) + days[is_leap_year(year)][(month-1)] + (day - 1);
-   time_t result = (seconds_in_day * days_since_epoch) + (60 * ((hour * 60) + min) + sec);
+   time_t days_since_epoch =
+       (days_from_1ad(year) - days_from_1ad(1970)) +
+       days[is_leap_year(year)][(month - 1)] + (day - 1);
+   time_t result =
+       (seconds_in_day * days_since_epoch) + (60 * ((hour * 60) + min) + sec);
 
    return result;
 }
-
 
 void setUp(void)
 {


### PR DESCRIPTION
Use a direct implementation of construct_date.
This avoids issues with mktime().

timegm() not used as not universal.

All tests pass with standard solution.