### PR TITLE
Updating shebang for better portability.

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LATEST=https://github.com/exercism/configlet/releases/latest
 

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 for D in exercises/*; do

--- a/bin/verify-indent
+++ b/bin/verify-indent
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-sh indent.sh
+bash indent.sh
 
 # This script fails when run by Travis if the diff is not checked twice
 # Unfortunately no better solution was found

--- a/indent.sh
+++ b/indent.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Indents all .c and .h files in the project that are not vendor code (ie: Unity).
 #


### PR DESCRIPTION
`#!/usr/bin/env bash` is supposed to be more portable than directly linking to /bin/bash.

I hit this while running on NixOS.