### PR TITLE
moved the free function

### DIFF
--- a/exercises/binary-search-tree/src/example.c
+++ b/exercises/binary-search-tree/src/example.c
@@ -8,7 +8,7 @@ static bool mem_ok;
 static int *parsed_tree;
 static size_t parsed_len;
 
-static void free_tree(node_t * head)
+void free_tree(node_t * head)
 {
    if (head == NULL)
       return;

--- a/exercises/binary-search-tree/src/example.h
+++ b/exercises/binary-search-tree/src/example.h
@@ -11,6 +11,7 @@ struct node {
 };
 
 node_t *build_tree(int *tree_data, size_t tree_data_len);
+void free_tree(node_t *tree);
 int *sorted_data(node_t * tree);
 
 #endif

--- a/exercises/binary-search-tree/src/example.h
+++ b/exercises/binary-search-tree/src/example.h
@@ -11,7 +11,7 @@ struct node {
 };
 
 node_t *build_tree(int *tree_data, size_t tree_data_len);
-void free_tree(node_t *tree);
+void free_tree(node_t * tree);
 int *sorted_data(node_t * tree);
 
 #endif

--- a/exercises/binary-search-tree/test/test_binary_search_tree.c
+++ b/exercises/binary-search-tree/test/test_binary_search_tree.c
@@ -13,15 +13,6 @@ void tearDown(void)
 {
 }
 
-static void free_tree(node_t * tree)
-{
-   if (tree == NULL)
-      return;
-   free_tree(tree->left);
-   free_tree(tree->right);
-   free(tree);
-}
-
 void test_data_data_is_retained(void)
 {
    int tree_data[] = { 4 };


### PR DESCRIPTION
I think it's bad the solution doesn't require freeing the tree for two reasons:
1. It's not hard to implement, and does teach something
2. I general it's a good habit to provide a free function, as I might allocate with a different function.