### PR TITLE
moved the gigasecond towards the side exercises to move word-count to core tracks

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,7 +42,7 @@
     {
       "slug": "word-count",
       "uuid": "1e4f4fcf-c32d-459f-8920-15ac56008666",
-      "core": false,
+      "core": true,
       "unlocked_by": "isogram",
       "difficulty": 3,
       "topics": [
@@ -67,7 +67,7 @@
     {
       "slug": "gigasecond",
       "uuid": "000340f6-e30d-4d49-a255-016237d6fe60",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [

--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
       "slug": "word-count",
       "uuid": "1e4f4fcf-c32d-459f-8920-15ac56008666",
       "core": true,
-      "unlocked_by": "isogram",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "filtering",
@@ -78,7 +78,7 @@
       "slug": "space-age",
       "uuid": "fc03c7de-b0c6-4806-90bb-e9dda846e660",
       "core": false,
-      "unlocked_by": "gigasecond",
+      "unlocked_by": "word-count",
       "difficulty": 1,
       "topics": [
         "functions"
@@ -88,7 +88,7 @@
       "slug": "meetup",
       "uuid": "a7baa53f-e828-457e-a456-ba3471494d80",
       "core": false,
-      "unlocked_by": "gigasecond",
+      "unlocked_by": "word-count",
       "difficulty": 4,
       "topics": [
         "control_flow_if_statements",


### PR DESCRIPTION
With giga-second being unhelpful and considered a clutter by myself, I suggested to swap it with word-count being harder but leaving room for improvement as the student might be publishing more iterations than with giga second. See issue #353 for clarifying situation.