### PR TITLE
Update test_word_count.c

### DIFF
--- a/exercises/word-count/test/test_word_count.c
+++ b/exercises/word-count/test/test_word_count.c
@@ -7,7 +7,7 @@
 #define STRING_SIZE (MAX_WORD_LENGTH + 1)
 
 word_count_word_t actual_solution[MAX_WORDS];
-word_count_word_t expected_solution[MAX_WORDS];
+word_count_word_t expected_solution[MAX_WORDS+1];
 void setUp(void)
 {
 }

--- a/exercises/word-count/test/test_word_count.c
+++ b/exercises/word-count/test/test_word_count.c
@@ -7,7 +7,7 @@
 #define STRING_SIZE (MAX_WORD_LENGTH + 1)
 
 word_count_word_t actual_solution[MAX_WORDS];
-word_count_word_t expected_solution[MAX_WORDS+1];
+word_count_word_t expected_solution[MAX_WORDS + 1];
 void setUp(void)
 {
 }


### PR DESCRIPTION
All the change does is prevent the test from crashing when it tries to write the 21st word for the excessive words test. 
Bug was found under Win7  with Dev-C++ and Mingw 8.1.0 but was working fine with Msys2.
