### PR TITLE
Moving to out of tree builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/configlet
 bin/configlet.exe
+build/
 **/*.out
 **/*.o
 .DS_Store

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,35 +1,55 @@
 #!/usr/bin/env bash
 set -e
 
-for D in exercises/*; do
-    CURRENT_DIR=$(pwd)
+# Move to the root directory of the repo so you can run this script from anywhere
+SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+cd "${SCRIPT_DIR}"/..
 
-    if [ -d "${D}" ]; then
-        # Get the exercise name from the test file
-        TEST_FILE=$(basename $(ls ${D}/test/test*))
-        STRIPPED_OF_EXTENSION="${TEST_FILE%.*}"
-        EXERCISE_NAME="${STRIPPED_OF_EXTENSION:5}"
+# Clone the exercises directory to avoid pollution
+rm -rf build
+cp -r exercises build
+
+cd build/
+
+execute_test () {
+    if [ -d "${1}" ]; then
+        (
+        cd "${1}"
+        # Get the exercise name from the directory
+        EXERCISE_NAME=$(echo "$1" | tr '-' '_')
+
+        echo "Running tests for ${EXERCISE_NAME}";
 
         #remove the ignore line
-        sed -i.bak 's/TEST_IGNORE();//' ${D}/test/test_*.c
+        sed -i 's/TEST_IGNORE();//' test/test_*.c
 
         # Copy the examples with the correct name for the exercise
-        if [ -e "${D}/src/example.c" ]
+        if [ -e "src/example.c" ]
         then
-          cp ${D}/src/example.c ${D}/src/${EXERCISE_NAME}.c
+          cp src/example.c src/"${EXERCISE_NAME}".c
         fi
 
-        if [ -e "${D}/src/example.h" ]
+        if [ -e "src/example.h" ]
         then
-          cp ${D}/src/example.h ${D}/src/${EXERCISE_NAME}.h
+          cp src/example.h src/"${EXERCISE_NAME}".h
         fi
 
         # Make it!
-        { cd ${D};
-          echo "Running tests for ${EXERCISE_NAME}";
-          make clean >> /dev/null;
-          make memcheck
-          cd ${CURRENT_DIR};
-        }
+        make clean >> /dev/null;
+        make memcheck
+        echo ""
+        )
     fi
-done
+}
+
+# Allow specifying which tests to run as arguments
+if [ $# -gt 0 ]; then
+    for exercise in "$@"; do
+        execute_test "$exercise"
+    done
+else
+    for exercise in *; do
+        execute_test "$exercise"
+    done
+fi
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -137,6 +137,12 @@ Firstly make sure you have the necessary tools installed (such as `indent`, [`gi
 ~/git/c$ ./bin/run-tests
 ```
 
+If you'd like to run only some of the tests to check your work, you can specify them as arguments to the run-tests script.
+
+```bash
+~/git/c$ ./bin/run-tests acronym all-your-base allergies
+```
+
 ### What Are the CI Scripts?
 You can see from the [.travis.yml](https://github.com/exercism/c/blob/master/.travis.yml) file that Travis is instructed to run scripts from the [`./bin`](https://github.com/exercism/c/tree/master/bin) directory.
 The work these scripts perform is described as follows:


### PR DESCRIPTION
Modifies the `bin/run-tests` script to use out of tree builds, and to allow running a subset of tests to improve development.

I verified POSIX compat using https://github.com/koalaman/shellcheck, which we can add to Travis easily if needed (there are warnings in both `verify-indent` and `fetch-configlet` that should probably be fixed if we enable it).