### PR TITLE
Switching memcheck to use Asan.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 
 before_install:
 - sudo apt-get -qq update
-- sudo apt-get install -y indent valgrind
+- sudo apt-get install -y indent
 
 script:
 - bin/fetch-configlet

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -26,12 +26,12 @@ execute_test () {
         # Copy the examples with the correct name for the exercise
         if [ -e "src/example.c" ]
         then
-          cp src/example.c src/"${EXERCISE_NAME}".c
+          mv src/example.c src/"${EXERCISE_NAME}".c
         fi
 
         if [ -e "src/example.h" ]
         then
-          cp src/example.h src/"${EXERCISE_NAME}".h
+          mv src/example.h src/"${EXERCISE_NAME}".h
         fi
 
         # Make it!

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -131,7 +131,7 @@ The good folks at fish-shell have [some great information](https://github.com/fi
 
 ### Run CI Scripts Locally
 You can also run individual scripts on your own machine before committing.
-Firstly make sure you have the necessary tools installed (such as `indent`, [`git`](https://git-scm.com/), [`sed`](https://www.gnu.org/software/sed/manual/sed.html), [`make`](https://www.gnu.org/software/make/), [`valgrind`](http://valgrind.org/) and a C compiler), and then run the required script from the repository root. For example:
+Firstly make sure you have the necessary tools installed (such as `indent`, [`git`](https://git-scm.com/), [`sed`](https://www.gnu.org/software/sed/manual/sed.html), [`make`](https://www.gnu.org/software/make/) and a C compiler), and then run the required script from the repository root. For example:
 
 ```bash
 ~/git/c$ ./bin/run-tests
@@ -155,5 +155,5 @@ The command for `configlet` used by Travis is [`lint`](https://github.com/exerci
 - `verify-indent` runs `indent` and verifies that it did not result in any file changes.
 If the check does result in file changes, Travis will output the details and report a failure on the related PR.
 
-- `run-tests` loops through each exercise, prepares the exercise for building and then builds it using `make`, runs the unit tests and then checks it for memory leaks with `valgrind`.
+- `run-tests` loops through each exercise, prepares the exercise for building and then builds it using `make`, runs the unit tests and then checks it for memory leaks with AddressSanitizer.
 If there are build errors, any test fails or there is a memory leak, Travis will output the details and report a failure on the related PR.

--- a/exercises/acronym/makefile
+++ b/exercises/acronym/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_acronym.c src/acronym.c src/acronym.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/acronym.c test/vendor/unity.c test/test_acronym.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/all-your-base/makefile
+++ b/exercises/all-your-base/makefile
@@ -11,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_all_your_base.c src/all_your_base.c src/all_your_base.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/all_your_base.c test/vendor/unity.c test/test_all_your_base.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/allergies/makefile
+++ b/exercises/allergies/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_allergies.c src/allergies.c src/allergies.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/allergies.c test/vendor/unity.c test/test_allergies.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/anagram/makefile
+++ b/exercises/anagram/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_anagram.c src/anagram.c src/anagram.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/anagram.c test/vendor/unity.c test/test_anagram.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/atbash-cipher/makefile
+++ b/exercises/atbash-cipher/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_atbash_cipher.c src/atbash_cipher.c src/atbash_cipher.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/atbash_cipher.c test/vendor/unity.c test/test_atbash_cipher.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/beer-song/makefile
+++ b/exercises/beer-song/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_beer_song.c src/beer_song.c src/beer_song.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/beer_song.c test/vendor/unity.c test/test_beer_song.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/binary-search-tree/makefile
+++ b/exercises/binary-search-tree/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_binary_search_tree.c src/binary_search_tree.c src/binary_search_tree.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/binary_search_tree.c test/vendor/unity.c test/test_binary_search_tree.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/binary-search/makefile
+++ b/exercises/binary-search/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_binary_search.c src/binary_search.c src/binary_search.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/binary_search.c test/vendor/unity.c test/test_binary_search.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/binary/makefile
+++ b/exercises/binary/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_binary.c src/binary.c src/binary.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/binary.c test/vendor/unity.c test/test_binary.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/bob/makefile
+++ b/exercises/bob/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_bob.c src/bob.c src/bob.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/bob.c test/vendor/unity.c test/test_bob.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/bracket-push/makefile
+++ b/exercises/bracket-push/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_bracket_push.c src/bracket_push.c src/bracket_push.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/bracket_push.c test/vendor/unity.c test/test_bracket_push.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/clock/makefile
+++ b/exercises/clock/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_clock.c src/clock.c src/clock.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/clock.c test/vendor/unity.c test/test_clock.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/collatz-conjecture/makefile
+++ b/exercises/collatz-conjecture/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_collatz_conjecture.c src/collatz_conjecture.c src/collatz_conjecture.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/collatz_conjecture.c test/vendor/unity.c test/test_collatz_conjecture.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/complex-numbers/makefile
+++ b/exercises/complex-numbers/makefile
@@ -10,23 +10,23 @@ CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
-CFLAGS += -DUNITY_FLOAT_TYPE=double
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_complex_numbers.c src/complex_numbers.c src/complex_numbers.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/complex_numbers.c test/vendor/unity.c test/test_complex_numbers.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/crypto-square/makefile
+++ b/exercises/crypto-square/makefile
@@ -11,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_crypto_square.c src/crypto_square.c src/crypto_square.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/crypto_square.c test/vendor/unity.c test/test_crypto_square.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/diamond/makefile
+++ b/exercises/diamond/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_diamond.c src/diamond.c src/diamond.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/diamond.c test/vendor/unity.c test/test_diamond.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/difference-of-squares/makefile
+++ b/exercises/difference-of-squares/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_difference_of_squares.c src/difference_of_squares.c src/difference_of_squares.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/difference_of_squares.c test/vendor/unity.c test/test_difference_of_squares.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/etl/makefile
+++ b/exercises/etl/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_etl.c src/etl.c src/etl.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/etl.c test/vendor/unity.c test/test_etl.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/etl/test/test_etl.c
+++ b/exercises/etl/test/test_etl.c
@@ -36,7 +36,7 @@ void test_a_single_letter(void)
    TEST_ASSERT_EQUAL_INT(expected_length, actual_length);
    TEST_ASSERT_EQUAL_INT(0, compare_map(expected_map, output, actual_length));
 
-   free(output);
+   //free(output);
 }
 
 void test_single_score_with_multiple_letters(void)

--- a/exercises/etl/test/test_etl.c
+++ b/exercises/etl/test/test_etl.c
@@ -36,7 +36,7 @@ void test_a_single_letter(void)
    TEST_ASSERT_EQUAL_INT(expected_length, actual_length);
    TEST_ASSERT_EQUAL_INT(0, compare_map(expected_map, output, actual_length));
 
-   //free(output);
+   free(output);
 }
 
 void test_single_score_with_multiple_letters(void)

--- a/exercises/gigasecond/makefile
+++ b/exercises/gigasecond/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_gigasecond.c src/gigasecond.c src/gigasecond.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/gigasecond.c test/vendor/unity.c test/test_gigasecond.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/grains/makefile
+++ b/exercises/grains/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_grains.c src/grains.c src/grains.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/grains.c test/vendor/unity.c test/test_grains.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/hamming/makefile
+++ b/exercises/hamming/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_hamming.c src/hamming.c src/hamming.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/hamming.c test/vendor/unity.c test/test_hamming.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/hello-world/makefile
+++ b/exercises/hello-world/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_hello_world.c src/hello_world.c src/hello_world.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/hello_world.c test/vendor/unity.c test/test_hello_world.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/isogram/makefile
+++ b/exercises/isogram/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_isogram.c src/isogram.c src/isogram.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/isogram.c test/vendor/unity.c test/test_isogram.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/largest-series-product/makefile
+++ b/exercises/largest-series-product/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_largest_series_product.c src/largest_series_product.c src/largest_series_product.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/largest_series_product.c test/vendor/unity.c test/test_largest_series_product.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/leap/makefile
+++ b/exercises/leap/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_leap.c src/leap.c src/leap.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/leap.c test/vendor/unity.c test/test_leap.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/linked-list/makefile
+++ b/exercises/linked-list/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_linked_list.c src/linked_list.c src/linked_list.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/linked_list.c test/vendor/unity.c test/test_linked_list.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/luhn/makefile
+++ b/exercises/luhn/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_luhn.c src/luhn.c src/luhn.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/luhn.c test/vendor/unity.c test/test_luhn.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/meetup/makefile
+++ b/exercises/meetup/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_meetup.c src/meetup.c src/meetup.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/meetup.c test/vendor/unity.c test/test_meetup.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/minesweeper/makefile
+++ b/exercises/minesweeper/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_minesweeper.c src/minesweeper.c src/minesweeper.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/minesweeper.c test/vendor/unity.c test/test_minesweeper.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/nth-prime/makefile
+++ b/exercises/nth-prime/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_nth_prime.c src/nth_prime.c src/nth_prime.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/nth_prime.c test/vendor/unity.c test/test_nth_prime.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/nucleotide-count/makefile
+++ b/exercises/nucleotide-count/makefile
@@ -1,29 +1,32 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
-CFLAGS = -std=c99
+CFLAGS  = -std=c99
 CFLAGS += -g
 CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: src/nucleotide_count.c src/nucleotide_count.h test/test_nucleotide_count.c
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/nucleotide_count.c test/vendor/unity.c test/test_nucleotide_count.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/palindrome-products/makefile
+++ b/exercises/palindrome-products/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_palindrome_products.c src/palindrome_products.c src/palindrome_products.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/palindrome_products.c test/vendor/unity.c test/test_palindrome_products.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/pangram/makefile
+++ b/exercises/pangram/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_pangram.c src/pangram.c src/pangram.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/pangram.c test/vendor/unity.c test/test_pangram.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/pascals-triangle/makefile
+++ b/exercises/pascals-triangle/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_pascals_triangle.c src/pascals_triangle.c src/pascals_triangle.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/pascals_triangle.c test/vendor/unity.c test/test_pascals_triangle.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/perfect-numbers/makefile
+++ b/exercises/perfect-numbers/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,20 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_perfect_numbers.c src/perfect_numbers.c src/perfect_numbers.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/perfect_numbers.c test/vendor/unity.c test/test_perfect_numbers.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/phone-number/makefile
+++ b/exercises/phone-number/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_phone_number.c src/phone_number.c src/phone_number.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/phone_number.c test/vendor/unity.c test/test_phone_number.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/pig-latin/makefile
+++ b/exercises/pig-latin/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_pig_latin.c src/pig_latin.c src/pig_latin.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/pig_latin.c test/vendor/unity.c test/test_pig_latin.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/prime-factors/makefile
+++ b/exercises/prime-factors/makefile
@@ -11,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_prime_factors.c src/prime_factors.c src/prime_factors.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/prime_factors.c test/vendor/unity.c test/test_prime_factors.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/queen-attack/makefile
+++ b/exercises/queen-attack/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_queen_attack.c src/queen_attack.c src/queen_attack.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/queen_attack.c test/vendor/unity.c test/test_queen_attack.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/raindrops/makefile
+++ b/exercises/raindrops/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_raindrops.c src/raindrops.c src/raindrops.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/raindrops.c test/vendor/unity.c test/test_raindrops.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/react/makefile
+++ b/exercises/react/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_react.c src/react.c src/react.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/react.c test/vendor/unity.c test/test_react.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/rna-transcription/makefile
+++ b/exercises/rna-transcription/makefile
@@ -1,29 +1,32 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
-CFLAGS = -std=c99
+CFLAGS  = -std=c99
 CFLAGS += -g
 CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_rna_transcription.c src/rna_transcription.c src/rna_transcription.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/rna_transcription.c test/vendor/unity.c test/test_rna_transcription.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/robot-simulator/makefile
+++ b/exercises/robot-simulator/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_robot_simulator.c src/robot_simulator.c src/robot_simulator.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/robot_simulator.c test/vendor/unity.c test/test_robot_simulator.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/roman-numerals/makefile
+++ b/exercises/roman-numerals/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_roman_numerals.c src/roman_numerals.c src/roman_numerals.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/roman_numerals.c test/vendor/unity.c test/test_roman_numerals.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/run-length-encoding/makefile
+++ b/exercises/run-length-encoding/makefile
@@ -11,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_run_length_encoding.c src/run_length_encoding.c src/run_length_encoding.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/run_length_encoding.c test/vendor/unity.c test/test_run_length_encoding.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/say/makefile
+++ b/exercises/say/makefile
@@ -11,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_say.c src/say.c src/say.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/say.c test/vendor/unity.c test/test_say.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/scrabble-score/makefile
+++ b/exercises/scrabble-score/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_scrabble_score.c src/scrabble_score.c src/scrabble_score.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/scrabble_score.c test/vendor/unity.c test/test_scrabble_score.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/secret-handshake/makefile
+++ b/exercises/secret-handshake/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_secret_handshake.c src/secret_handshake.c src/secret_handshake.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/secret_handshake.c test/vendor/unity.c test/test_secret_handshake.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/series/makefile
+++ b/exercises/series/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_series.c src/series.c src/series.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/series.c test/vendor/unity.c test/test_series.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/sieve/makefile
+++ b/exercises/sieve/makefile
@@ -11,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_sieve.c src/sieve.c src/sieve.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/sieve.c test/vendor/unity.c test/test_sieve.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/space-age/makefile
+++ b/exercises/space-age/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_space_age.c src/space_age.c src/space_age.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/space_age.c test/vendor/unity.c test/test_space_age.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/sublist/makefile
+++ b/exercises/sublist/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_sublist.c src/sublist.c src/sublist.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/sublist.c test/vendor/unity.c test/test_sublist.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/sum-of-multiples/makefile
+++ b/exercises/sum-of-multiples/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_sum_of_multiples.c src/sum_of_multiples.c src/sum_of_multiples.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/sum_of_multiples.c test/vendor/unity.c test/test_sum_of_multiples.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/triangle/makefile
+++ b/exercises/triangle/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_triangle.c src/triangle.c src/triangle.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/triangle.c test/vendor/unity.c test/test_triangle.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/two-fer/makefile
+++ b/exercises/two-fer/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_two_fer.c src/two_fer.c src/two_fer.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/two_fer.c test/vendor/unity.c test/test_two_fer.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/word-count/makefile
+++ b/exercises/word-count/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_word_count.c src/word_count.c src/word_count.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/word_count.c test/vendor/unity.c test/test_word_count.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)

--- a/exercises/wordy/makefile
+++ b/exercises/wordy/makefile
@@ -1,5 +1,7 @@
-### If you wish to use extra libraries,
-### add their flags in the "LIBS" variable (like we do with "CFLAGS").
+### If you wish to use extra libraries (math.h for instance),
+### add their flags here (-lm in our case) in the "LIBS" variable.
+
+LIBS = -lm
 
 ###
 CFLAGS  = -std=c99
@@ -9,21 +11,22 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 
-VFLAGS  = --quiet
-VFLAGS += --tool=memcheck
-VFLAGS += --leak-check=full
-VFLAGS += --error-exitcode=1
+ASANFLAGS  = -fsanitize=address
+ASANFLAGS += -fno-common
+ASANFLAGS += -fno-omit-frame-pointer
 
 test: tests.out
 	@./tests.out
 
-memcheck: tests.out
-	@valgrind $(VFLAGS) ./tests.out
+memcheck: test/*.c src/*.c src/*.h
+	@echo Compiling $@
+	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
+	@./memcheck.out
 	@echo "Memory check passed"
 
 clean:
 	rm -rf *.o *.out *.out.dSYM
 
-tests.out: test/test_wordy.c src/wordy.c src/wordy.h
+tests.out: test/*.c src/*.c src/*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) src/wordy.c test/vendor/unity.c test/test_wordy.c -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o tests.out $(LIBS)


### PR DESCRIPTION
This swaps out Valgrind for AddressSanitizer and standardizes on an identical makefile for all tests, as I proposed in #370.

Closes #370 

(Temporarily setting this as WIP to demonstrate that CI still catches memory leaks)
