### PR TITLE
Adding ShellCheck linter to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
 - bin/fetch-configlet
 - bin/configlet lint .
 - bin/verify-indent
+- shellcheck bin/*
 - bin/run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ script:
 - bin/fetch-configlet
 - bin/configlet lint .
 - bin/verify-indent
-- shellcheck bin/*
+- shellcheck bin/fetch-configlet bin/verify-indent bin/run-tests indent.sh
 - bin/run-tests

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -29,4 +29,4 @@ esac)
 VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
-curl -s --location $URL | tar xz -C bin/
+curl -s --location "$URL" | tar xz -C bin/

--- a/bin/verify-indent
+++ b/bin/verify-indent
@@ -6,7 +6,7 @@ bash indent.sh
 # Unfortunately no better solution was found
 git diff --quiet
 
-if ! $(git diff --quiet)
+if ! git diff --quiet
 then
   echo "Incorrect style detected:"
   echo

--- a/indent.sh
+++ b/indent.sh
@@ -7,8 +7,8 @@ INDENT=""
 
 if [ -x "$(command -v gindent)" ]; then
   INDENT=gindent
-elif [ "$OSTYPE" = "darwin"* ]; then
-  echo "ERROR:  Install gnu-indent using home brew to run this script."
+elif [[ "$OSTYPE" = "darwin"* ]]; then
+  echo "ERROR:  Install gnu-indent using Homebrew to run this script."
   exit 126
 elif [ -x "$(command -v indent)" ]; then
   INDENT=indent
@@ -17,7 +17,9 @@ else
   exit 126
 fi
 
-for f in $(find exercises/ -not -path '*/vendor/*' -name '*.c' -or -not -path '*/vendor/*' -name '*.h'); do
-  $INDENT -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4 -cli0 -d0 -di1 -nfc1 -i3 -nut -ip0 -l80 -lp -npcs -nprs -npsl -sai -saf -saw -ncs -nsc -sob -nfca -cp33 -ss -il1 $f
-  rm $f~ 2> /dev/null
-done
+# Run indent on every file
+# shellcheck disable=SC2046
+$INDENT -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4 -cli0 -d0 -di1 -nfc1 -i3 -nut -ip0 -l80 -lp -npcs -nprs -npsl -sai -saf -saw -ncs -nsc -sob -nfca -cp33 -ss -il1 $(find exercises/ -not -path '*/vendor/*' -name '*.c' -or -not -path '*/vendor/*' -name '*.h')
+
+# Remove all the backup files created by indent
+find . -name '*~' -delete


### PR DESCRIPTION
This adds a [ShellCheck](https://github.com/koalaman/shellcheck) static analysis run to lint the bash scripts under bin/. Travis has it installed by default, so it can be invoked pretty easily.