### PR TITLE
Adding test_pattern to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "language": "C",
   "active": true,
   "blurb": "C is a small, general-purpose, imperative programming language with a static type system, scopes, and structures. It's typically used as an alternative to assembly programming, such as in operating systems.",
+  "test_pattern": "test/test_.*[.]c",
   "exercises": [
     {
       "slug": "hello-world",


### PR DESCRIPTION
This regex needs to match the test file path starting from the root of the exercise's directory. This is to fix the issue described in exercism/exercism#4797 where we were displaying the contents of the unit test framework on the website.

I _believe_ this is right but I'm not quite sure how I could test this without just merging it and watching the rollout to see if I broke it. It's pretty low impact, so it might be easiest just to merge it, babysit the change and then patch it quickly if it broke. The website is pretty much live with HEAD so it could be handled pretty quick.