### PR TITLE
isogram: Add test case for duplicates following non-letter character

### DIFF
--- a/exercises/isogram/test/test_isogram.c
+++ b/exercises/isogram/test/test_isogram.c
@@ -45,16 +45,16 @@ void test_longest_known_isogram(void)
    TEST_ASSERT_TRUE(is_isogram("subdermatoglyphic"));
 }
 
-void test_same_first_and_last_characters(void)
-{
-   TEST_IGNORE();
-   TEST_ASSERT_FALSE(is_isogram("oreo"));
-}
-
 void test_duplicated_letter_mixed_case(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("Alphabet"));
+}
+
+void test_duplicated_letter_mixed_case_lowercase_first(void)
+{
+   TEST_IGNORE();
+   TEST_ASSERT_FALSE(is_isogram("alphAbet"));
 }
 
 void test_non_letter_char(void)
@@ -63,10 +63,16 @@ void test_non_letter_char(void)
    TEST_ASSERT_TRUE(is_isogram("thumbscrew-japingly"));
 }
 
+void test_duplicated_letter_following_non_letter_char(void)
+{
+   TEST_IGNORE();
+   TEST_ASSERT_FALSE(is_isogram("thumbscrew-jappingly"));
+}
+
 void test_duplicated_non_letter_char(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_TRUE(is_isogram("Hjelmqvist-Gryb-Zock-Pfund-Wax"));
+   TEST_ASSERT_TRUE(is_isogram("six-year-old"));
 }
 
 void test_multiple_whitespace(void)
@@ -81,6 +87,12 @@ void test_duplicated_letter_within_word(void)
    TEST_ASSERT_FALSE(is_isogram("accentor"));
 }
 
+void test_same_first_and_last_characters(void)
+{
+   TEST_IGNORE();
+   TEST_ASSERT_FALSE(is_isogram("angola"));
+}
+
 int main(void)
 {
    UnityBegin("test/test_isogram.c");
@@ -89,14 +101,16 @@ int main(void)
    RUN_TEST(test_null);
    RUN_TEST(test_lower_case_only);
    RUN_TEST(test_duplicated_letter);
-   RUN_TEST(test_same_first_and_last_characters);
    RUN_TEST(test_duplicated_letter_from_end_of_alphabet);
    RUN_TEST(test_longest_known_isogram);
    RUN_TEST(test_duplicated_letter_mixed_case);
+   RUN_TEST(test_duplicated_letter_mixed_case_lowercase_first);
    RUN_TEST(test_non_letter_char);
+   RUN_TEST(test_duplicated_letter_following_non_letter_char);
    RUN_TEST(test_duplicated_non_letter_char);
    RUN_TEST(test_multiple_whitespace);
    RUN_TEST(test_duplicated_letter_within_word);
+   RUN_TEST(test_same_first_and_last_characters);
 
    return UnityEnd();
 }


### PR DESCRIPTION
Without this test, you can pass all tests while ignoring everything after the first non-letter character.