### PR TITLE
Allergies: Use stack allocated arrays.

### DIFF
--- a/exercises/allergies/src/allergies.h
+++ b/exercises/allergies/src/allergies.h
@@ -1,6 +1,8 @@
 #ifndef ALLERGIES_H
 #define ALLERGIES_H
 
+#include <stdbool.h>
+
 typedef enum {
    ALLERGEN_EGGS = 0,
    ALLERGEN_PEANUTS,
@@ -10,12 +12,12 @@ typedef enum {
    ALLERGEN_CHOCOLATE,
    ALLERGEN_POLLEN,
    ALLERGEN_CATS,
-   ALLERGEN_COUNT
+   ALLERGEN_COUNT,
 } allergen_t;
 
 typedef struct {
    int count;
-   allergen_t *allergens;
+   bool allergens[ALLERGEN_COUNT];
 } allergen_list_t;
 
 #endif

--- a/exercises/allergies/src/example.c
+++ b/exercises/allergies/src/example.c
@@ -1,32 +1,20 @@
 #include "allergies.h"
 #include <stdlib.h>
 
-static const unsigned int scores[] = {
-   1,
-   2,
-   4,
-   8,
-   16,
-   32,
-   64,
-   128
-};
-
 bool is_allergic_to(allergen_t allergen, unsigned int score)
 {
-   return ((score & scores[allergen]) == scores[allergen]);
+   return ((score & (1 << allergen)) != 0);
 }
 
-void get_allergens(unsigned int score, allergen_list_t * list)
+allergen_list_t get_allergens(unsigned int score)
 {
-   list->allergens = calloc(ALLERGEN_COUNT, sizeof(allergen_t));
-   list->count = 0;
+   allergen_list_t list = { 0, };
 
-   for (allergen_t allergen = 0; allergen < ALLERGEN_COUNT; allergen++) {
+   for (allergen_t allergen = 0; allergen < ALLERGEN_COUNT; ++allergen) {
       if (is_allergic_to(allergen, score)) {
-         score -= scores[allergen];
-         list->allergens[list->count] = allergen;
-         list->count++;
+         list.allergens[allergen] = true;
+         ++list.count;
       }
    }
+   return list;
 }

--- a/exercises/allergies/src/example.c
+++ b/exercises/allergies/src/example.c
@@ -8,7 +8,10 @@ bool is_allergic_to(allergen_t allergen, unsigned int score)
 
 allergen_list_t get_allergens(unsigned int score)
 {
-   allergen_list_t list = { 0, };
+   allergen_list_t list = {
+      .count = 0,
+      .allergens = {0},
+   };
 
    for (allergen_t allergen = 0; allergen < ALLERGEN_COUNT; ++allergen) {
       if (is_allergic_to(allergen, score)) {

--- a/exercises/allergies/src/example.h
+++ b/exercises/allergies/src/example.h
@@ -12,15 +12,15 @@ typedef enum {
    ALLERGEN_CHOCOLATE,
    ALLERGEN_POLLEN,
    ALLERGEN_CATS,
-   ALLERGEN_COUNT
+   ALLERGEN_COUNT,
 } allergen_t;
 
 typedef struct {
    int count;
-   allergen_t *allergens;
+   bool allergens[ALLERGEN_COUNT];
 } allergen_list_t;
 
 bool is_allergic_to(allergen_t allergen, unsigned int score);
-void get_allergens(unsigned int score, allergen_list_t * list);
+allergen_list_t get_allergens(unsigned int score);
 
 #endif

--- a/exercises/allergies/test/test_allergies.c
+++ b/exercises/allergies/test/test_allergies.c
@@ -10,30 +10,9 @@ void tearDown(void)
 {
 }
 
-//helper functions
-void list_count_is(int count, allergen_list_t * list)
-{
-   TEST_ASSERT_EQUAL(count, list->count);
-}
-
-void list_contains(allergen_t allergen, allergen_list_t * list)
-{
-   bool allergen_found = false;
-
-   for (int i = 0; i < list->count; i++) {
-      if (list->allergens[i] == allergen) {
-         allergen_found = true;
-         break;
-      }
-   }
-
-   TEST_ASSERT_TRUE(allergen_found);
-}
-
-//Tests start here
 void test_no_allergies_means_not_allergic(void)
 {
-   int score = 0;
+   unsigned int score = 0;
 
    TEST_ASSERT_FALSE(is_allergic_to(ALLERGEN_PEANUTS, score));
    TEST_ASSERT_FALSE(is_allergic_to(ALLERGEN_CATS, score));
@@ -43,7 +22,7 @@ void test_no_allergies_means_not_allergic(void)
 void test_is_allergic_to_eggs(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   int score = 1;
+   unsigned int score = 1;
 
    TEST_ASSERT_TRUE(is_allergic_to(ALLERGEN_EGGS, score));
 }
@@ -51,7 +30,7 @@ void test_is_allergic_to_eggs(void)
 void test_is_allergic_to_eggs_in_addition_to_other_stuff(void)
 {
    TEST_IGNORE();
-   int score = 5;
+   unsigned int score = 5;
 
    TEST_ASSERT_TRUE(is_allergic_to(ALLERGEN_EGGS, score));
    TEST_ASSERT_TRUE(is_allergic_to(ALLERGEN_SHELLFISH, score));
@@ -61,145 +40,101 @@ void test_is_allergic_to_eggs_in_addition_to_other_stuff(void)
 void test_no_allergies_at_all(void)
 {
    TEST_IGNORE();
-   int score = 0;
-   allergen_list_t list;
+   unsigned int score = 0;
+   allergen_list_t list = get_allergens(score);
 
-   get_allergens(score, &list);
-
-   list_count_is(0, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(0, list.count);
 }
 
 void test_allergic_to_just_eggs(void)
 {
    TEST_IGNORE();
-   int score = 1;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(1);
 
-   get_allergens(score, &list);
-
-   list_count_is(1, &list);
-   list_contains(ALLERGEN_EGGS, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(1, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_EGGS]);
 }
 
 void test_allergic_to_just_peanuts(void)
 {
    TEST_IGNORE();
-   int score = 2;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(2);
 
-   get_allergens(score, &list);
-
-   list_count_is(1, &list);
-   list_contains(ALLERGEN_PEANUTS, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(1, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_PEANUTS]);
 }
 
 void test_allergic_to_just_strawberries(void)
 {
    TEST_IGNORE();
-   int score = 8;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(8);
 
-   get_allergens(score, &list);
-
-   list_count_is(1, &list);
-   list_contains(ALLERGEN_STRAWBERRIES, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(1, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_STRAWBERRIES]);
 }
 
 void test_allergic_to_eggs_and_peanuts(void)
 {
    TEST_IGNORE();
-   int score = 3;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(3);
 
-   get_allergens(score, &list);
-
-   list_count_is(2, &list);
-   list_contains(ALLERGEN_EGGS, &list);
-   list_contains(ALLERGEN_PEANUTS, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(2, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_EGGS]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_PEANUTS]);
 }
 
 void test_allergic_to_more_than_eggs_but_not_peanuts(void)
 {
    TEST_IGNORE();
-   int score = 5;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(5);
 
-   get_allergens(score, &list);
-
-   list_count_is(2, &list);
-   list_contains(ALLERGEN_EGGS, &list);
-   list_contains(ALLERGEN_SHELLFISH, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(2, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_EGGS]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_SHELLFISH]);
 }
 
 void test_allergic_to_lots_of_stuff(void)
 {
    TEST_IGNORE();
-   int score = 248;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(248);
 
-   get_allergens(score, &list);
-
-   list_count_is(5, &list);
-   list_contains(ALLERGEN_STRAWBERRIES, &list);
-   list_contains(ALLERGEN_TOMATOES, &list);
-   list_contains(ALLERGEN_CHOCOLATE, &list);
-   list_contains(ALLERGEN_POLLEN, &list);
-   list_contains(ALLERGEN_CATS, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(5, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_STRAWBERRIES]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_TOMATOES]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_CHOCOLATE]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_POLLEN]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_CATS]);
 }
 
 void test_allergic_to_everything(void)
 {
    TEST_IGNORE();
-   int score = 255;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(255);
 
-   get_allergens(score, &list);
-
-   list_count_is(8, &list);
-   list_contains(ALLERGEN_EGGS, &list);
-   list_contains(ALLERGEN_PEANUTS, &list);
-   list_contains(ALLERGEN_SHELLFISH, &list);
-   list_contains(ALLERGEN_STRAWBERRIES, &list);
-   list_contains(ALLERGEN_TOMATOES, &list);
-   list_contains(ALLERGEN_CHOCOLATE, &list);
-   list_contains(ALLERGEN_POLLEN, &list);
-   list_contains(ALLERGEN_CATS, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(8, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_EGGS]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_PEANUTS]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_SHELLFISH]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_STRAWBERRIES]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_TOMATOES]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_CHOCOLATE]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_POLLEN]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_CATS]);
 }
 
 void test_ignore_non_allergen_score_parts(void)
 {
    TEST_IGNORE();
-   int score = 509;
-   allergen_list_t list;
+   allergen_list_t list = get_allergens(509);
 
-   get_allergens(score, &list);
-
-   list_count_is(7, &list);
-   list_contains(ALLERGEN_EGGS, &list);
-   list_contains(ALLERGEN_SHELLFISH, &list);
-   list_contains(ALLERGEN_STRAWBERRIES, &list);
-   list_contains(ALLERGEN_TOMATOES, &list);
-   list_contains(ALLERGEN_CHOCOLATE, &list);
-   list_contains(ALLERGEN_POLLEN, &list);
-   list_contains(ALLERGEN_CATS, &list);
-
-   free(list.allergens);
+   TEST_ASSERT_EQUAL(7, list.count);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_EGGS]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_SHELLFISH]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_STRAWBERRIES]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_TOMATOES]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_CHOCOLATE]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_POLLEN]);
+   TEST_ASSERT_TRUE(list.allergens[ALLERGEN_CATS]);
 }
 
 int main(void)


### PR DESCRIPTION
Closes #321 

This removes all the heap allocations from the allergies exercise. I also simplified the exercise by just switching to using an array of bools for output instead of an array of allergen values so that it more directly demonstrates how you can think of a bitfield as an array of bools.

I explicitly did _not_ update this to the [new test suite](https://github.com/exercism/problem-specifications/blob/master/exercises/allergies/canonical-data.json) since that would require a full overhaul of the tests, and this change is intended to just address the present concerns.