### PR TITLE
word-count: change to TEST_ASSERT_EQUAL_STRING_LEN() in tests

### DIFF
--- a/exercises/word-count/.meta/hints.md
+++ b/exercises/word-count/.meta/hints.md
@@ -1,0 +1,1 @@
+- Note that the tests for this exercise expect the output words to be proper C strings. That is, they should be NUL terminated. See https://en.wikipedia.org/wiki/C_string_handling

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -11,6 +11,8 @@ come: 1
 free: 1
 ```
 
+- Note that the tests for this exercise expect the output words to be proper C strings. That is, they should be NUL terminated. See https://en.wikipedia.org/wiki/C_string_handling
+
 ## Getting Started
 
 Make sure you have read the "Guides" section of the

--- a/exercises/word-count/test/test_word_count.c
+++ b/exercises/word-count/test/test_word_count.c
@@ -8,6 +8,7 @@
 
 word_count_word_t actual_solution[MAX_WORDS];
 word_count_word_t expected_solution[MAX_WORDS + 1];
+
 void setUp(void)
 {
 }
@@ -28,8 +29,9 @@ static void check_solution(word_count_word_t * expected_solution,
    for (int index = 0; index < MAX_WORDS; index++) {
       TEST_ASSERT_EQUAL(expected_solution[index].count,
                         actual_solution[index].count);
-      TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_solution[index].text,
-                                    actual_solution[index].text, STRING_SIZE);
+      TEST_ASSERT_EQUAL_STRING_LEN(expected_solution[index].text,
+                                   actual_solution[index].text,
+                                   strlen(expected_solution[index].text));
    }
 }
 


### PR DESCRIPTION
Per #357, have changed test to use `TEST_ASSERT_EQUAL_STRING_LEN` test assert instead of `TEST_ASSERT_EQUAL_UINT8_ARRAY`.

Change is still under discussion on the issue, so have marked as WIP for now.