### PR TITLE
Update the *sieve* exercise.

### DIFF
--- a/exercises/sieve/src/example.c
+++ b/exercises/sieve/src/example.c
@@ -1,50 +1,42 @@
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
 #include "sieve.h"
 
-unsigned int sieve(const unsigned int limit, primes_array_t primes)
+#include <math.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+uint32_t sieve(uint32_t limit, uint32_t * primes, size_t max_primes)
 {
-   unsigned int number_of_primes = 0;
-
-   // clear the results
-   memset(primes, 0, sizeof(*primes));
-
-   if (limit > 1) {
-      //allocate 1 more than limit for convenience so the number and the index are same
-      unsigned char *number_is_prime = malloc(limit + 1);
-      memset(number_is_prime, 1, limit + 1);
-
-      unsigned int max_factor = sqrt(limit) + 1;
-
-      // mark 0 and 1 as not prime
-      for (unsigned int i = 0; i < 2; i++) {
-         number_is_prime[i] = 0;
-      }
-
-      // mark the remaining numbers in the array according to the algo.
-      for (unsigned int index = 2; index < max_factor;) {
-         // mark all of multiples that can't be prime
-         for (unsigned int non_prime_index = (2 * index);
-              non_prime_index < (limit + 1); non_prime_index += index) {
-            number_is_prime[non_prime_index] = 0;
-         }
-
-         // adjust the index
-         do {
-            index++;
-            if (number_is_prime[index]) {
-               break;
-            }
-         } while (index <= max_factor);
-      }
-      // collect and count the primes found
-      for (unsigned int i = 1; i < limit + 1; i++) {
-         if (number_is_prime[i]) {
-            primes[number_of_primes++] = i;
-         }
-      }
-      free(number_is_prime);
+   if (limit <= 1) {
+      // no primes that small
+      return 0;
    }
-   return number_of_primes;
+   // allocate one boolean for each number in [0,limit]
+   bool *data = calloc(limit + 1, sizeof(*data));
+   if (!data) {
+      return 0;
+   }
+
+   uint32_t n_primes = 0;
+
+   for (uint32_t i = 2; i <= limit; i++) {
+      if (data[i]) {
+         // current number `i` is already marked
+         continue;
+      }
+      // `i` is the smallest number that is not marked and therefore prime
+      primes[n_primes++] = i;
+
+      if (n_primes == max_primes) {
+         // we reached the maximum number of primes
+         break;
+      }
+      // mark the multiples of `i` in [i*2, limit]
+      for (uint32_t p = 2 * i; p <= limit; p += i) {
+         data[p] = true;
+      }
+   }
+
+   free(data);
+
+   return n_primes;
 }

--- a/exercises/sieve/src/example.c
+++ b/exercises/sieve/src/example.c
@@ -10,15 +10,15 @@ uint32_t sieve(uint32_t limit, uint32_t * primes, size_t max_primes)
       return 0;
    }
    // allocate one boolean for each number in [0,limit]
-   bool *data = calloc(limit + 1, sizeof(*data));
-   if (!data) {
+   bool *is_marked = calloc(limit + 1, sizeof(*is_marked));
+   if (!is_marked) {
       return 0;
    }
 
    uint32_t n_primes = 0;
 
    for (uint32_t i = 2; i <= limit; i++) {
-      if (data[i]) {
+      if (is_marked[i]) {
          // current number `i` is already marked
          continue;
       }
@@ -31,11 +31,11 @@ uint32_t sieve(uint32_t limit, uint32_t * primes, size_t max_primes)
       }
       // mark the multiples of `i` in [i*2, limit]
       for (uint32_t p = 2 * i; p <= limit; p += i) {
-         data[p] = true;
+         is_marked[p] = true;
       }
    }
 
-   free(data);
+   free(is_marked);
 
    return n_primes;
 }

--- a/exercises/sieve/src/example.c
+++ b/exercises/sieve/src/example.c
@@ -1,6 +1,5 @@
 #include "sieve.h"
 
-#include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/exercises/sieve/src/sieve.h
+++ b/exercises/sieve/src/sieve.h
@@ -1,10 +1,13 @@
 #ifndef SIEVE_H
 #define SIEVE_H
 
-#define MAX_LIMIT_TESTED (1000)
+#include <stdint.h>
+#include <stddef.h>
 
-typedef unsigned int primes_array_t[MAX_LIMIT_TESTED];
-
-unsigned int sieve(const unsigned int limit, primes_array_t primes);
+/// Calculate at most `max_primes` prime numbers in the interval [2,limit] 
+/// using the Sieve of Eratosthenes and store the prime numbers in `primes`
+/// in increasing order.
+/// The function returns the number of calculate primes.
+uint32_t sieve(uint32_t limit, uint32_t * primes, size_t max_primes);
 
 #endif

--- a/exercises/sieve/test/test_sieve.c
+++ b/exercises/sieve/test/test_sieve.c
@@ -1,9 +1,9 @@
 #include <string.h>
-#include "vendor/unity.h"
 #include "../src/sieve.h"
+#include "vendor/unity.h"
 
-static primes_array_t result_array;
-#define ARRAY_LENGTH(x)   sizeof(x)/sizeof(x[0])
+#define RESULT_ARRAY_LEN (1000)
+static uint32_t result_array[RESULT_ARRAY_LEN];
 
 void setUp(void)
 {
@@ -15,96 +15,98 @@ void tearDown(void)
 
 static void test_no_primes_under_two(void)
 {
-   const unsigned int limit = 1;
-   const unsigned int expected_prime_count = 0;
-   unsigned int result_prime_count;
-
-   memset(result_array, 0, sizeof(result_array));
-
-   result_prime_count = sieve(limit, result_array);
+   const uint32_t limit = 1;
+   const uint32_t expected_prime_count = 0;
+   const uint32_t result_prime_count =
+       sieve(limit, result_array, RESULT_ARRAY_LEN);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
 }
 
 static void test_find_first_prime(void)
 {
-   TEST_IGNORE();               // delete this line to run test
-   const unsigned int limit = 2;
-   const primes_array_t expected_prime_array = { 2 };
-   const unsigned int expected_prime_count = 1;
-   unsigned int result_prime_count;
+   TEST_IGNORE();
+   const uint32_t limit = 2;
+   const uint32_t expected_prime_array[] = { 2 };
+   const uint32_t expected_prime_count = 1;
 
-   memset(result_array, 0, sizeof(result_array));
+   const uint32_t result_prime_count =
+       sieve(limit, result_array, RESULT_ARRAY_LEN);
 
-   result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
-
+                                expected_prime_count);
 }
 
 static void test_find_primes_up_to_10(void)
 {
    TEST_IGNORE();
-   const unsigned int limit = 10;
-   const primes_array_t expected_prime_array = { 2, 3, 5, 7 };
-   const unsigned int expected_prime_count = 4;
-   unsigned int result_prime_count;
+   const uint32_t limit = 10;
+   const uint32_t expected_prime_array[] = { 2, 3, 5, 7 };
+   const uint32_t expected_prime_count = 4;
 
-   memset(result_array, 0, sizeof(result_array));
+   const uint32_t result_prime_count =
+       sieve(limit, result_array, RESULT_ARRAY_LEN);
 
-   result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
-
+                                expected_prime_count);
 }
 
 static void test_limit_is_prime(void)
 {
    TEST_IGNORE();
-   const unsigned int limit = 13;
-   const primes_array_t expected_prime_array = { 2, 3, 5, 7, 11, 13 };
-   const unsigned int expected_prime_count = 6;
-   unsigned int result_prime_count;
+   const uint32_t limit = 13;
+   const uint32_t expected_prime_array[] = { 2, 3, 5, 7, 11, 13 };
+   const uint32_t expected_prime_count = 6;
 
-   memset(result_array, 0, sizeof(result_array));
+   const uint32_t result_prime_count =
+       sieve(limit, result_array, RESULT_ARRAY_LEN);
 
-   result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
+                                expected_prime_count);
+}
 
+static void test_limit_is_prime_and_small_max_primes(void)
+{
+   TEST_IGNORE();
+   const uint32_t limit = 13;
+   const uint32_t expected_prime_array[] = { 2, 3, 5, 7, 11, 13 };
+   const uint32_t expected_prime_count = 4;
+
+   const uint32_t result_prime_count = sieve(limit, result_array, 4);
+
+   TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
+   TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
+                                expected_prime_count);
 }
 
 static void test_find_primes_up_to_1000(void)
 {
    TEST_IGNORE();
-   const unsigned int limit = 1000;
-   const primes_array_t expected_prime_array = {
-      2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
-      61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127,
-      131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193,
-      197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269,
-      271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349,
-      353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431,
-      433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503,
-      509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599,
-      601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673,
-      677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761,
-      769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857,
-      859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947,
-      953, 967, 971, 977, 983, 991, 997
+   const uint32_t limit = 1000;
+   const uint32_t expected_prime_array[] = {
+      2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
+      47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107,
+      109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181,
+      191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263,
+      269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349,
+      353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433,
+      439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521,
+      523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613,
+      617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701,
+      709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809,
+      811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887,
+      907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997
    };
-   const unsigned int expected_prime_count = 168;
-   unsigned int result_prime_count;
+   const uint32_t expected_prime_count = 168;
 
-   memset(result_array, 0, sizeof(result_array));
+   const uint32_t result_prime_count =
+       sieve(limit, result_array, RESULT_ARRAY_LEN);
 
-   result_prime_count = sieve(limit, result_array);
    TEST_ASSERT_EQUAL(expected_prime_count, result_prime_count);
    TEST_ASSERT_EQUAL_UINT_ARRAY(expected_prime_array, result_array,
-                                ARRAY_LENGTH(expected_prime_array));
-
+                                expected_prime_count);
 }
 
 int main(void)
@@ -115,6 +117,7 @@ int main(void)
    RUN_TEST(test_find_first_prime);
    RUN_TEST(test_find_primes_up_to_10);
    RUN_TEST(test_limit_is_prime);
+   RUN_TEST(test_limit_is_prime_and_small_max_primes);
    RUN_TEST(test_find_primes_up_to_1000);
 
    return UnityEnd();


### PR DESCRIPTION
Rationale:
- Signature used relied on some array of fixed size
- Types used are rather arbitrary
- Test cases exhibited bad style