### PR TITLE
Correct function name style

### DIFF
--- a/exercises/armstrong-numbers/src/example.c
+++ b/exercises/armstrong-numbers/src/example.c
@@ -1,7 +1,7 @@
 #include "armstrong_numbers.h"
 #include <math.h>
 
-static uint16_t getDigitCount(uint32_t candidate)
+static uint16_t get_digit_count(uint32_t candidate)
 {
    uint16_t digit_count = 0;
    while (candidate > 0) {
@@ -11,13 +11,13 @@ static uint16_t getDigitCount(uint32_t candidate)
    return digit_count;
 }
 
-bool isArmstrongNumber(uint32_t candidate)
+bool is_armstrong_number(uint32_t candidate)
 {
    bool result = false;
    if (candidate < 10) {
       result = true;
    } else if (candidate >= 100) {
-      uint16_t digit_count = getDigitCount(candidate);
+      uint16_t digit_count = get_digit_count(candidate);
       uint32_t sum = 0, n = candidate;
       while (n > 0 && sum <= candidate) {
          uint16_t r = n % 10;

--- a/exercises/armstrong-numbers/src/example.h
+++ b/exercises/armstrong-numbers/src/example.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-bool isArmstrongNumber(uint32_t candidate);
+bool is_armstrong_number(uint32_t candidate);
 
 #endif

--- a/exercises/armstrong-numbers/test/test_armstrong_numbers.c
+++ b/exercises/armstrong-numbers/test/test_armstrong_numbers.c
@@ -11,55 +11,55 @@ void tearDown(void)
 
 static void test_zero_is_an_armstrong_number(void)
 {
-   TEST_ASSERT_TRUE(isArmstrongNumber(0));
+   TEST_ASSERT_TRUE(is_armstrong_number(0));
 }
 
 static void test_single_digit_numbers_are_armstrong_numbers(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   TEST_ASSERT_TRUE(isArmstrongNumber(5));
+   TEST_ASSERT_TRUE(is_armstrong_number(5));
 }
 
 static void test_there_are_no_two_digit_armstrong_numbers(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_FALSE(isArmstrongNumber(10));
+   TEST_ASSERT_FALSE(is_armstrong_number(10));
 }
 
 static void test_three_digit_number_that_is_an_armstrong_number(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_TRUE(isArmstrongNumber(153));
+   TEST_ASSERT_TRUE(is_armstrong_number(153));
 }
 
 static void test_three_digit_number_that_is_not_an_armstrong_number(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_FALSE(isArmstrongNumber(100));
+   TEST_ASSERT_FALSE(is_armstrong_number(100));
 }
 
 static void test_four_digit_number_that_is_an_armstrong_number(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_TRUE(isArmstrongNumber(9474));
+   TEST_ASSERT_TRUE(is_armstrong_number(9474));
 }
 
 static void test_four_digit_number_that_is_not_an_armstrong_number(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_FALSE(isArmstrongNumber(9475));
+   TEST_ASSERT_FALSE(is_armstrong_number(9475));
 }
 
 static void test_seven_digit_number_that_is_an_armstrong_number(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_TRUE(isArmstrongNumber(9926315));
+   TEST_ASSERT_TRUE(is_armstrong_number(9926315));
 }
 
 static void test_seven_digit_number_that_is_not_an_armstrong_number(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_FALSE(isArmstrongNumber(9926314));
+   TEST_ASSERT_FALSE(is_armstrong_number(9926314));
 }
 
 int main(void)

--- a/exercises/darts/src/example.c
+++ b/exercises/darts/src/example.c
@@ -11,7 +11,7 @@ static const uint8_t MIDDLE_CIRCLE_SCORE = 5;
 static const uint8_t OUTER_CIRCLE_SCORE = 1;
 static const uint8_t OFF_BOARD_SCORE = 0;
 
-static float distanceFromOrigin(coordinate_t point)
+static float distance_from_origin(coordinate_t point)
 {
    // calculate distance using pythagorean theorem:
    // d = sqrt(|xC - xP|^2 + |yC - yP|^2)
@@ -23,7 +23,7 @@ uint8_t score(coordinate_t landing_position)
 {
    uint8_t score = OFF_BOARD_SCORE;
    float landingPositionDistanceFromOrigin =
-       distanceFromOrigin(landing_position);
+       distance_from_origin(landing_position);
 
    if (landingPositionDistanceFromOrigin <= INNER_CIRCLE_RADIUS)
       score = INNER_CIRCLE_SCORE;

--- a/exercises/resistor-color-duo/src/example.c
+++ b/exercises/resistor-color-duo/src/example.c
@@ -1,6 +1,6 @@
 #include "resistor_color_duo.h"
 
-uint16_t colorCode(resistor_band_t colors[])
+uint16_t color_code(resistor_band_t colors[])
 {
    return (uint16_t) (colors[0] * 10 + colors[1]);
 }

--- a/exercises/resistor-color-duo/src/example.h
+++ b/exercises/resistor-color-duo/src/example.h
@@ -16,6 +16,6 @@ typedef enum {
    WHITE = 9
 } resistor_band_t;
 
-uint16_t colorCode(resistor_band_t colors[]);
+uint16_t color_code(resistor_band_t colors[]);
 
 #endif

--- a/exercises/resistor-color-duo/test/test_resistor_color_duo.c
+++ b/exercises/resistor-color-duo/test/test_resistor_color_duo.c
@@ -11,35 +11,35 @@ void tearDown(void)
 
 static void test_brown_and_black(void)
 {
-   uint16_t actual = colorCode((resistor_band_t[]){ BROWN, BLACK });
+   uint16_t actual = color_code((resistor_band_t[]){ BROWN, BLACK });
    TEST_ASSERT_EQUAL_UINT16(10, actual);
 }
 
 static void test_blue_and_grey(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   uint16_t actual = colorCode((resistor_band_t[]){ BLUE, GREY });
+   uint16_t actual = color_code((resistor_band_t[]){ BLUE, GREY });
    TEST_ASSERT_EQUAL_UINT16(68, actual);
 }
 
 static void test_yellow_and_violet(void)
 {
    TEST_IGNORE();
-   uint16_t actual = colorCode((resistor_band_t[]){ YELLOW, VIOLET });
+   uint16_t actual = color_code((resistor_band_t[]){ YELLOW, VIOLET });
    TEST_ASSERT_EQUAL_UINT16(47, actual);
 }
 
 static void test_orange_and_orange(void)
 {
    TEST_IGNORE();
-   uint16_t actual = colorCode((resistor_band_t[]){ ORANGE, ORANGE });
+   uint16_t actual = color_code((resistor_band_t[]){ ORANGE, ORANGE });
    TEST_ASSERT_EQUAL_UINT16(33, actual);
 }
 
 static void test_ignore_additional_colors(void)
 {
    TEST_IGNORE();
-   uint16_t actual = colorCode((resistor_band_t[]){ GREEN, BROWN, ORANGE });
+   uint16_t actual = color_code((resistor_band_t[]){ GREEN, BROWN, ORANGE });
    TEST_ASSERT_EQUAL_UINT16(51, actual);
 }
 

--- a/exercises/resistor-color-trio/src/example.c
+++ b/exercises/resistor-color-trio/src/example.c
@@ -1,7 +1,7 @@
 #include "resistor_color_trio.h"
 #include <math.h>
 
-resistor_value_t colorCode(resistor_band_t colors[])
+resistor_value_t color_code(resistor_band_t colors[])
 {
    resistor_value_t resistor = { 0, 0 };
    uint16_t digits = ((uint16_t) colors[0]) * 10 + colors[1];

--- a/exercises/resistor-color-trio/src/example.h
+++ b/exercises/resistor-color-trio/src/example.h
@@ -31,6 +31,6 @@ typedef struct {
    resistor_unit_t unit;
 } resistor_value_t;
 
-resistor_value_t colorCode(resistor_band_t colors[]);
+resistor_value_t color_code(resistor_band_t colors[]);
 
 #endif

--- a/exercises/resistor-color-trio/test/test_resistor_color_trio.c
+++ b/exercises/resistor-color-trio/test/test_resistor_color_trio.c
@@ -29,8 +29,7 @@ static void test_blue_grey_brown(void)
 static void test_red_black_red(void)
 {
    TEST_IGNORE();
-   resistor_value_t actual =
-       color_code((resistor_band_t[]){ RED, BLACK, RED });
+   resistor_value_t actual = color_code((resistor_band_t[]){ RED, BLACK, RED });
    TEST_ASSERT_EQUAL_UINT16(2, actual.value);
    TEST_ASSERT_EQUAL(KILOOHMS, actual.unit);
 }

--- a/exercises/resistor-color-trio/test/test_resistor_color_trio.c
+++ b/exercises/resistor-color-trio/test/test_resistor_color_trio.c
@@ -12,7 +12,7 @@ void tearDown(void)
 static void test_orange_orange_black(void)
 {
    resistor_value_t actual =
-       colorCode((resistor_band_t[]){ ORANGE, ORANGE, BLACK });
+       color_code((resistor_band_t[]){ ORANGE, ORANGE, BLACK });
    TEST_ASSERT_EQUAL_UINT16(33, actual.value);
    TEST_ASSERT_EQUAL(OHMS, actual.unit);
 }
@@ -21,7 +21,7 @@ static void test_blue_grey_brown(void)
 {
    TEST_IGNORE();               // delete this line to run test
    resistor_value_t actual =
-       colorCode((resistor_band_t[]){ BLUE, GREY, BROWN });
+       color_code((resistor_band_t[]){ BLUE, GREY, BROWN });
    TEST_ASSERT_EQUAL_UINT16(680, actual.value);
    TEST_ASSERT_EQUAL(OHMS, actual.unit);
 }
@@ -29,7 +29,8 @@ static void test_blue_grey_brown(void)
 static void test_red_black_red(void)
 {
    TEST_IGNORE();
-   resistor_value_t actual = colorCode((resistor_band_t[]){ RED, BLACK, RED });
+   resistor_value_t actual =
+       color_code((resistor_band_t[]){ RED, BLACK, RED });
    TEST_ASSERT_EQUAL_UINT16(2, actual.value);
    TEST_ASSERT_EQUAL(KILOOHMS, actual.unit);
 }
@@ -38,7 +39,7 @@ static void test_green_brown_orange(void)
 {
    TEST_IGNORE();
    resistor_value_t actual =
-       colorCode((resistor_band_t[]){ GREEN, BROWN, ORANGE });
+       color_code((resistor_band_t[]){ GREEN, BROWN, ORANGE });
    TEST_ASSERT_EQUAL_UINT16(51, actual.value);
    TEST_ASSERT_EQUAL(KILOOHMS, actual.unit);
 }
@@ -47,7 +48,7 @@ static void test_yellow_violet_yellow(void)
 {
    TEST_IGNORE();
    resistor_value_t actual =
-       colorCode((resistor_band_t[]){ YELLOW, VIOLET, YELLOW });
+       color_code((resistor_band_t[]){ YELLOW, VIOLET, YELLOW });
    TEST_ASSERT_EQUAL_UINT16(470, actual.value);
    TEST_ASSERT_EQUAL(KILOOHMS, actual.unit);
 }

--- a/exercises/resistor-color/src/example.c
+++ b/exercises/resistor-color/src/example.c
@@ -5,7 +5,7 @@ static const resistor_band_t band_colors[] = {
    GREEN, BLUE, VIOLET, GREY, WHITE
 };
 
-uint16_t colorCode(resistor_band_t color)
+uint16_t color_code(resistor_band_t color)
 {
    return (uint16_t) color;
 }

--- a/exercises/resistor-color/src/example.h
+++ b/exercises/resistor-color/src/example.h
@@ -16,7 +16,7 @@ typedef enum {
    WHITE = 9
 } resistor_band_t;
 
-uint16_t colorCode(resistor_band_t color);
+uint16_t color_code(resistor_band_t color);
 
 const resistor_band_t *colors(void);
 

--- a/exercises/resistor-color/test/test_resistor_color.c
+++ b/exercises/resistor-color/test/test_resistor_color.c
@@ -13,19 +13,19 @@ void tearDown(void)
 
 static void test_black(void)
 {
-   TEST_ASSERT_EQUAL_UINT16(0, colorCode(BLACK));
+   TEST_ASSERT_EQUAL_UINT16(0, color_code(BLACK));
 }
 
 static void test_white(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   TEST_ASSERT_EQUAL_UINT16(9, colorCode(WHITE));
+   TEST_ASSERT_EQUAL_UINT16(9, color_code(WHITE));
 }
 
 static void test_orange(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT16(3, colorCode(ORANGE));
+   TEST_ASSERT_EQUAL_UINT16(3, color_code(ORANGE));
 }
 
 static void test_colors(void)


### PR DESCRIPTION
As noticed by  @gabriel376 on #413, I've been using the wrong style for function names 🤦‍♂ .
This PR updates them.
(I've only checked on the exercises that I've introduced, there may still be other occurrences of this in the repo).