### PR TITLE
Correct incorrect arguments to UnityBegin()

### DIFF
--- a/exercises/anagram/test/test_anagram.c
+++ b/exercises/anagram/test/test_anagram.c
@@ -243,7 +243,7 @@ static void test_misleading_unicode_anagrams(void)
 
 int main(void)
 {
-   UnityBegin("anagram.c");
+   UnityBegin("test/test_anagram.c");
 
    RUN_TEST(test_no_matches);
    RUN_TEST(test_detect_simple_anagram);

--- a/exercises/clock/test/test_clock.c
+++ b/exercises/clock/test/test_clock.c
@@ -537,7 +537,7 @@ static void test_compare_full_clock_and_zeroed_clock(void)
 
 int main(void)
 {
-   UnityBegin("clock.c");
+   UnityBegin("test/test_clock.c");
 
    RUN_TEST(test_on_the_hour);
    RUN_TEST(test_past_the_hour);

--- a/exercises/collatz-conjecture/test/test_collatz_conjecture.c
+++ b/exercises/collatz-conjecture/test/test_collatz_conjecture.c
@@ -34,7 +34,7 @@ static void test_negative_value_is_an_error(void)
 
 int main(void)
 {
-   UnityBegin("collatz_conjecture.c");
+   UnityBegin("test/test_collatz_conjecture.c");
 
    RUN_TEST(test_zero_steps_for_one);
    RUN_TEST(test_divide_if_even);

--- a/exercises/largest-series-product/test/test_largest_series_product.c
+++ b/exercises/largest-series-product/test/test_largest_series_product.c
@@ -113,7 +113,7 @@ static void test_rejects_invalid_character_in_digits(void)
 
 int main(void)
 {
-   UnityBegin("largest_series_product.c");
+   UnityBegin("test/test_largest_series_product.c");
 
    RUN_TEST(test_can_find_the_largest_product_of_2_with_numbers_in_order);
    RUN_TEST(test_can_find_the_largest_product_of_2);

--- a/exercises/linked-list/test/test_linked_list.c
+++ b/exercises/linked-list/test/test_linked_list.c
@@ -99,7 +99,7 @@ static void test_shift_returns_list_data(void)
 
 int main(void)
 {
-   UnityBegin("test/test_leap.c");
+   UnityBegin("test/test_linked_list.c");
 
    RUN_TEST(test_new_list);
    RUN_TEST(test_is_list_empty_when_empty);

--- a/exercises/raindrops/test/test_raindrops.c
+++ b/exercises/raindrops/test/test_raindrops.c
@@ -116,7 +116,7 @@ static void test_big_prime_yields_itself(void)
 
 int main(void)
 {
-   UnityBegin("raindrops.c");
+   UnityBegin("test/test_raindrops.c");
 
    RUN_TEST(test_one_yields_itself);
    RUN_TEST(test_three_yields_pling);

--- a/exercises/robot-simulator/test/test_robot_simulator.c
+++ b/exercises/robot-simulator/test/test_robot_simulator.c
@@ -164,7 +164,7 @@ static void test_simulate_move_east_and_north(void)
 
 int main(void)
 {
-   UnityBegin("test/test_word_count.c");
+   UnityBegin("test/test_robot_simulator.c");
 
    RUN_TEST(test_init);
    RUN_TEST(test_invalid_initial_heading);


### PR DESCRIPTION
I noticed that a few other exercises also had incorrect arguments passed to the `UnityBegin()` call.
This PR corrects them.
To paraphrase the Pokémon theme: hope I've caught 'em all!