### PR TITLE
armstrong-numbers: added function declaration

### DIFF
--- a/exercises/armstrong-numbers/src/armstrong_numbers.h
+++ b/exercises/armstrong-numbers/src/armstrong_numbers.h
@@ -1,4 +1,6 @@
 #ifndef ARMSTRONG_NUMBERS
 #define ARMSTRONG_NUMBERS
 
+int is_armstrong_number(int candidate);
+
 #endif


### PR DESCRIPTION
This PR is simultaneously an issue, and a potential fix for that issue.

I've been going through these exercises with a couple friends, serving as their offline mentor while they go through these. Right off the bat we came to recognize that some of the exercises are shipped with the function declaration in the header, and others aren't.

It's particularly frustrating for them, since they're so new to the language, and they're not accustomed to the way GCC can throw ten or more errors, most not particularly informative, ( eg. "what's an empty translation unit?" ).

I thought I'd try and contribute and ask for some more strict standards on the C track. For example:

1. Function declarations in the header should either be there for all exercises or for none.
2. A central decision on types. If function declarations are provided, they should either all use stdbool for true/false functions, or none of them should. Similarly for functions with number parameters or return types should either all use stdint types, or none of them should.
3. It'd be lovely if there were a singular style with provided code. Snake case, camel case, etc.

I've noticed that most of the other languages don't provide function declarations, but other languages also don't have the waterfall of compiler errors, and other languages don't really reproduce the same experience of C's headers.

I'd be happy to do some cleanup work either way (removing or adding function decl's, etc.). I just think it'd be a huge improvement to add some consistency.