### PR TITLE
list-ops: Compare array contents

### DIFF
--- a/exercises/list-ops/test/test_list_ops.c
+++ b/exercises/list-ops/test/test_list_ops.c
@@ -1,12 +1,41 @@
 #include "vendor/unity.h"
 #include "../src/list_ops.h"
 
+const int MAX_STRING_LEN = 100;
+
 void setUp(void)
 {
 }
 
 void tearDown(void)
 {
+}
+
+static char *print_list(list_t * list)
+{
+   char *array = (char *)malloc(MAX_STRING_LEN * sizeof(char));
+   char *ptr = array;
+   for (size_t i = 0; i < list->length; i++) {
+      int printed = snprintf(ptr, MAX_STRING_LEN - (ptr - array), " %d ",
+                             (list->values[i]));
+      ptr += printed;
+      if (ptr - array > MAX_STRING_LEN) {
+         break;
+      }
+   }
+   return array;
+}
+
+static char *create_error_message(list_t * expected, list_t * actual)
+{
+   char *message = (char *)malloc(MAX_STRING_LEN * sizeof(char));
+   char *expected_string = print_list(expected);
+   char *actual_string = print_list(actual);
+   snprintf(message, MAX_STRING_LEN, "[%s] != [%s]", expected_string,
+            actual_string);
+   free(expected_string);
+   free(actual_string);
+   return message;
 }
 
 static void check_lists_match(list_t * expected, list_t * actual)
@@ -20,9 +49,13 @@ static void check_lists_match(list_t * expected, list_t * actual)
                              "List lengths differ");
 
    // check values match in non-zero length lists
-   if (expected->length)
-      TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, sizeof(list_value_t),
-                                     expected->length);
+   if (expected->length) {
+      char *error_message = create_error_message(expected, actual);
+      TEST_ASSERT_EQUAL_MEMORY_ARRAY_MESSAGE(expected->values, actual->values,
+                                             sizeof(list_value_t),
+                                             expected->length, error_message);
+      free(error_message);
+   }
 }
 
 static bool filter_modulo(list_value_t value)

--- a/exercises/list-ops/test/test_list_ops.c
+++ b/exercises/list-ops/test/test_list_ops.c
@@ -13,7 +13,7 @@ void tearDown(void)
 
 static char *print_list(list_t * list)
 {
-   char *array = (char *)malloc(MAX_STRING_LEN * sizeof(char));
+   char *array = malloc(MAX_STRING_LEN * sizeof(char));
    char *ptr = array;
    for (size_t i = 0; i < list->length; i++) {
       int printed = snprintf(ptr, MAX_STRING_LEN - (ptr - array), " %d ",
@@ -28,7 +28,7 @@ static char *print_list(list_t * list)
 
 static char *create_error_message(list_t * expected, list_t * actual)
 {
-   char *message = (char *)malloc(MAX_STRING_LEN * sizeof(char));
+   char *message = malloc(MAX_STRING_LEN * sizeof(char));
    char *expected_string = print_list(expected);
    char *actual_string = print_list(actual);
    snprintf(message, MAX_STRING_LEN, "[%s] != [%s]", expected_string,


### PR DESCRIPTION
The current solution only compares the length of the arrays, and never compares the contents.

The first two arguments to `TEST_ASSERT_EQUAL_MEMORY_ARRAY` are cast to pointers, and internally Unity doesn't access the memory locations if the pointers are equal, so we don't get the crashes you'd expect from accessing invalid addresses.

Also added a message here, because Unity's error messages are not exactly useful.

Pointed out on slack - https://exercism-team.slack.com/archives/CATCU7LSJ/p1573889084013200