### PR TITLE
list-ops: Check return value of reverse_list()

### DIFF
--- a/exercises/list-ops/src/example.c
+++ b/exercises/list-ops/src/example.c
@@ -111,13 +111,17 @@ list_t *reverse_list(list_t * list)
    if (!list)
       return NULL;
 
-   for (size_t i = 0; i < list->length / 2; ++i) {
-      list_value_t swap = list->values[i];
-      list->values[i] = list->values[list->length - 1 - i];
-      list->values[list->length - 1 - i] = swap;
+   list_t *reversed = malloc(sizeof(*list) + sizeof(list_value_t) * list->length);
+
+   if (!reversed)
+      return NULL;
+   
+   reversed->length = list->length;
+   for (size_t i = 0, j = reversed->length - 1; i < reversed->length; i++, j--) {
+      reversed->values[i] = list->values[j]; 
    }
 
-   return list;
+   return reversed;
 }
 
 void delete_list(list_t * list)

--- a/exercises/list-ops/src/example.c
+++ b/exercises/list-ops/src/example.c
@@ -35,7 +35,7 @@ list_t *append_list(list_t * list1, list_t * list2)
    return list;
 }
 
-list_t *filter_list(list_t * list, bool(*filter) (list_value_t value))
+list_t *filter_list(list_t * list, bool (*filter)(list_value_t value))
 {
    if (!list || !filter)
       return NULL;
@@ -111,14 +111,15 @@ list_t *reverse_list(list_t * list)
    if (!list)
       return NULL;
 
-   list_t *reversed = malloc(sizeof(*list) + sizeof(list_value_t) * list->length);
+   list_t *reversed =
+       malloc(sizeof(*list) + sizeof(list_value_t) * list->length);
 
    if (!reversed)
       return NULL;
-   
+
    reversed->length = list->length;
    for (size_t i = 0, j = reversed->length - 1; i < reversed->length; i++, j--) {
-      reversed->values[i] = list->values[j]; 
+      reversed->values[i] = list->values[j];
    }
 
    return reversed;

--- a/exercises/list-ops/test/test_list_ops.c
+++ b/exercises/list-ops/test/test_list_ops.c
@@ -311,11 +311,12 @@ static void test_reverse_empty_list(void)
    list_t *list = new_list(0, NULL);
    list_t *expected = new_list(0, NULL);
 
-   reverse_list(list);
-   check_lists_match(expected, list);
+   list_t *actual = reverse_list(list);
+   check_lists_match(expected, actual);
 
    delete_list(list);
    delete_list(expected);
+   delete_list(actual);
 }
 
 static void test_reverse_non_empty_list(void)
@@ -324,11 +325,12 @@ static void test_reverse_non_empty_list(void)
    list_t *list = new_list(4, (list_value_t[]){ 1, 3, 5, 7 });
    list_t *expected = new_list(4, (list_value_t[]){ 7, 5, 3, 1 });
 
-   reverse_list(list);
-   check_lists_match(expected, list);
+   list_t *actual = reverse_list(list);
+   check_lists_match(expected, actual);
 
    delete_list(list);
    delete_list(expected);
+   delete_list(actual);
 }
 
 int main(void)

--- a/exercises/list-ops/test/test_list_ops.c
+++ b/exercises/list-ops/test/test_list_ops.c
@@ -314,6 +314,7 @@ static void test_reverse_empty_list(void)
    list_t *actual = reverse_list(list);
    check_lists_match(expected, actual);
 
+   delete_list(list);
    delete_list(expected);
    delete_list(actual);
 }
@@ -327,6 +328,7 @@ static void test_reverse_non_empty_list(void)
    list_t *actual = reverse_list(list);
    check_lists_match(expected, actual);
 
+   delete_list(list);
    delete_list(expected);
    delete_list(actual);
 }

--- a/exercises/list-ops/test/test_list_ops.c
+++ b/exercises/list-ops/test/test_list_ops.c
@@ -314,7 +314,6 @@ static void test_reverse_empty_list(void)
    list_t *actual = reverse_list(list);
    check_lists_match(expected, actual);
 
-   delete_list(list);
    delete_list(expected);
    delete_list(actual);
 }
@@ -328,7 +327,6 @@ static void test_reverse_non_empty_list(void)
    list_t *actual = reverse_list(list);
    check_lists_match(expected, actual);
 
-   delete_list(list);
    delete_list(expected);
    delete_list(actual);
 }


### PR DESCRIPTION
The type signature for `reverse_list()` suggests the function should return a new `list_t` but the tests don't actually test the return value; only the same list that is passed to `reverse_list()`.