### PR TITLE
Make targets phony where appropriate

### DIFF
--- a/exercises/acronym/makefile
+++ b/exercises/acronym/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/all-your-base/makefile
+++ b/exercises/all-your-base/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/allergies/makefile
+++ b/exercises/allergies/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/anagram/makefile
+++ b/exercises/anagram/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/armstrong-numbers/makefile
+++ b/exercises/armstrong-numbers/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/atbash-cipher/makefile
+++ b/exercises/atbash-cipher/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/beer-song/makefile
+++ b/exercises/beer-song/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/binary-search-tree/makefile
+++ b/exercises/binary-search-tree/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/binary-search/makefile
+++ b/exercises/binary-search/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/binary/makefile
+++ b/exercises/binary/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/bob/makefile
+++ b/exercises/bob/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/circular-buffer/makefile
+++ b/exercises/circular-buffer/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/clock/makefile
+++ b/exercises/clock/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/collatz-conjecture/makefile
+++ b/exercises/collatz-conjecture/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/complex-numbers/makefile
+++ b/exercises/complex-numbers/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/crypto-square/makefile
+++ b/exercises/crypto-square/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/darts/makefile
+++ b/exercises/darts/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/diamond/makefile
+++ b/exercises/diamond/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/difference-of-squares/makefile
+++ b/exercises/difference-of-squares/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/etl/makefile
+++ b/exercises/etl/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/gigasecond/makefile
+++ b/exercises/gigasecond/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/grade-school/makefile
+++ b/exercises/grade-school/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/grains/makefile
+++ b/exercises/grains/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/hamming/makefile
+++ b/exercises/hamming/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/hello-world/makefile
+++ b/exercises/hello-world/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/isogram/makefile
+++ b/exercises/isogram/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/largest-series-product/makefile
+++ b/exercises/largest-series-product/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/leap/makefile
+++ b/exercises/leap/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/linked-list/makefile
+++ b/exercises/linked-list/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/list-ops/makefile
+++ b/exercises/list-ops/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/luhn/makefile
+++ b/exercises/luhn/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/matching-brackets/makefile
+++ b/exercises/matching-brackets/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/meetup/makefile
+++ b/exercises/meetup/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/minesweeper/makefile
+++ b/exercises/minesweeper/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/nth-prime/makefile
+++ b/exercises/nth-prime/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/nucleotide-count/makefile
+++ b/exercises/nucleotide-count/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/palindrome-products/makefile
+++ b/exercises/palindrome-products/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/pangram/makefile
+++ b/exercises/pangram/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/pascals-triangle/makefile
+++ b/exercises/pascals-triangle/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/perfect-numbers/makefile
+++ b/exercises/perfect-numbers/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/phone-number/makefile
+++ b/exercises/phone-number/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/pig-latin/makefile
+++ b/exercises/pig-latin/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/prime-factors/makefile
+++ b/exercises/prime-factors/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/pythagorean-triplet/makefile
+++ b/exercises/pythagorean-triplet/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/queen-attack/makefile
+++ b/exercises/queen-attack/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/raindrops/makefile
+++ b/exercises/raindrops/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/rational-numbers/makefile
+++ b/exercises/rational-numbers/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/react/makefile
+++ b/exercises/react/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/resistor-color-duo/makefile
+++ b/exercises/resistor-color-duo/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/resistor-color-trio/makefile
+++ b/exercises/resistor-color-trio/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/resistor-color/makefile
+++ b/exercises/resistor-color/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/rna-transcription/makefile
+++ b/exercises/rna-transcription/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/robot-simulator/makefile
+++ b/exercises/robot-simulator/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/roman-numerals/makefile
+++ b/exercises/roman-numerals/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/run-length-encoding/makefile
+++ b/exercises/run-length-encoding/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/saddle-points/makefile
+++ b/exercises/saddle-points/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/say/makefile
+++ b/exercises/say/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/scrabble-score/makefile
+++ b/exercises/scrabble-score/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/secret-handshake/makefile
+++ b/exercises/secret-handshake/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/series/makefile
+++ b/exercises/series/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/sieve/makefile
+++ b/exercises/sieve/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/space-age/makefile
+++ b/exercises/space-age/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/square-root/makefile
+++ b/exercises/square-root/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/sublist/makefile
+++ b/exercises/sublist/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/sum-of-multiples/makefile
+++ b/exercises/sum-of-multiples/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/triangle/makefile
+++ b/exercises/triangle/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/two-fer/makefile
+++ b/exercises/two-fer/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/word-count/makefile
+++ b/exercises/word-count/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 

--- a/exercises/wordy/makefile
+++ b/exercises/wordy/makefile
@@ -17,15 +17,18 @@ ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 
+.PHONY: test
 test: tests.out
 	@./tests.out
 
+.PHONY: memcheck
 memcheck: test/*.c src/*.c src/*.h
 	@echo Compiling $@
 	@$(CC) $(ASANFLAGS) $(CFLAGS) src/*.c test/vendor/unity.c test/*.c -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 
+.PHONY: clean
 clean:
 	rm -rf *.o *.out *.out.dSYM
 


### PR DESCRIPTION
This fixes the root cause of https://github.com/exercism/c/issues/439.

In `make` if there's a target shouldn't correspond to a file and that you want to run unconditionally, you need to mark it as `.PHONY`. This tells `make` to ignore any files/folders that happen to have the same name as the target (otherwise `make` will use the timestamp of that file to determine whether to run the target).

Where this burned us is that we have a target named `test` and we have a directory `test/`. The target `test` depends upon `tests.out` and so `make test` will only run `./tests.out` if `tests.out` is newer than `test/`. You can see this yourself by doing a `touch test` to trick `make` into thinking that `test` does not need to be run because its inputs are older than `test/`. With this change `make` will ignore `test/` and treat the target `test` as just a fancy name, not a file/folder.