### PR TITLE
hello-world: Add explanatory comments

### DIFF
--- a/exercises/hello-world/src/hello_world.c
+++ b/exercises/hello-world/src/hello_world.c
@@ -1,5 +1,14 @@
+// Include the standard definitions header from the standard library, so that we
+// have access to `NULL`. This can be removed if your changes remove the need
+// for NULL.
+#include <stddef.h>
+
 #include "hello_world.h"
 
+// Define the function itself.
 const char *hello(void)
 {
+    // To fix this function, change the return statement here to instead return
+    // a string equivelent to the string expected by the failing test.
+    return NULL;
 }

--- a/exercises/hello-world/src/hello_world.c
+++ b/exercises/hello-world/src/hello_world.c
@@ -8,7 +8,7 @@
 // Define the function itself.
 const char *hello(void)
 {
-    // To fix this function, change the return statement here to instead return
-    // a string equivelent to the string expected by the failing test.
-    return NULL;
+   // To fix this function, change the return statement here to instead return
+   // a string equivelent to the string expected by the failing test.
+   return NULL;
 }

--- a/exercises/hello-world/src/hello_world.c
+++ b/exercises/hello-world/src/hello_world.c
@@ -1,6 +1,6 @@
 // Include the standard definitions header from the standard library, so that we
-// have access to `NULL`. This can be removed if your changes remove the need
-// for NULL.
+// have access to 'NULL'. This can be removed if your changes remove the need
+// for 'NULL'.
 #include <stddef.h>
 
 #include "hello_world.h"

--- a/exercises/hello-world/src/hello_world.h
+++ b/exercises/hello-world/src/hello_world.h
@@ -1,6 +1,14 @@
+// This is called an include guard, which ensures that the header is only
+// included once. You could alternatively use '#pragma once'. See
+// https://en.wikipedia.org/wiki/Include_guard .
 #ifndef HELLO_WORLD_H
 #define HELLO_WORLD_H
 
+// Declare the 'hello()' function, which takes no arguments and returns a
+// 'const char *', i.e. a pointer to a character (in this case the first
+// character in a string). The function itself is defined in the hello_world.c
+// source file. Ths function is called by the test case(s) in the test source
+// file test/test_hello_world.c .
 const char *hello(void);
 
 #endif

--- a/exercises/hello-world/src/hello_world.h
+++ b/exercises/hello-world/src/hello_world.h
@@ -1,6 +1,6 @@
 // This is called an include guard, which ensures that the header is only
 // included once. You could alternatively use '#pragma once'. See
-// https://en.wikipedia.org/wiki/Include_guard .
+// https://en.wikipedia.org/wiki/Include_guard.
 #ifndef HELLO_WORLD_H
 #define HELLO_WORLD_H
 
@@ -8,7 +8,7 @@
 // 'const char *', i.e. a pointer to a character (in this case the first
 // character in a string). The function itself is defined in the hello_world.c
 // source file. Ths function is called by the test case(s) in the test source
-// file test/test_hello_world.c .
+// file test/test_hello_world.c.
 const char *hello(void);
 
 #endif

--- a/exercises/hello-world/test/test_hello_world.c
+++ b/exercises/hello-world/test/test_hello_world.c
@@ -17,10 +17,10 @@ void tearDown(void)
 // Defines a single test.
 static void test_hello(void)
 {
-   // Check if hello() function returns "Hello, World!"
-   // This test is expected to fail after first downloading this exercise
-   // To make this test pass, fix the hello() function in the src/hello_world.c
-   // source file.
+   // Check if the 'hello()' function returns "Hello, World!"
+   // This test is expected to fail after first downloading this exercise.
+   // To make this test pass, fix the 'hello()' function definition in the
+   // source file src/hello_world.c .
    TEST_ASSERT_EQUAL_STRING("Hello, World!", hello());
 }
 

--- a/exercises/hello-world/test/test_hello_world.c
+++ b/exercises/hello-world/test/test_hello_world.c
@@ -1,20 +1,30 @@
-#include <stddef.h>
+// Include the test framework.
 #include "vendor/unity.h"
+
+// Include the header file with the declarations of the functions you create.
 #include "../src/hello_world.h"
 
+// Runs before every test.
 void setUp(void)
 {
 }
 
+// Runs after every test.
 void tearDown(void)
 {
 }
 
+// Defines a single test.
 static void test_hello(void)
 {
+   // Check if hello() function returns "Hello, World!"
+   // This test is expected to fail after first downloading this exercise
+   // To make this test pass, fix the hello() function in the src/hello_world.c
+   // source file.
    TEST_ASSERT_EQUAL_STRING("Hello, World!", hello());
 }
 
+// Runs the test(s)
 int main(void)
 {
    UnityBegin("test/test_hello_world.c");

--- a/exercises/hello-world/test/test_hello_world.c
+++ b/exercises/hello-world/test/test_hello_world.c
@@ -20,7 +20,7 @@ static void test_hello(void)
    // Check if the 'hello()' function returns "Hello, World!"
    // This test is expected to fail after first downloading this exercise.
    // To make this test pass, fix the 'hello()' function definition in the
-   // source file src/hello_world.c .
+   // source file src/hello_world.c.
    TEST_ASSERT_EQUAL_STRING("Hello, World!", hello());
 }
 


### PR DESCRIPTION
Closes #392 

Have added inline comments inspired by the examples from other tracks linked on the referenced issue.

Have also changed the example function definition to now have a valid return statement, so that the first build does not fail (required adding `#include <stddef.h>` for `NULL`).

Also moved the `#include <stddef.h>` out of the test file as it is not used there