### PR TITLE
Pascal's Triangle: keep inner loop in `check` inside triangle bounds

### DIFF
--- a/exercises/pascals-triangle/test/test_pascals_triangle.c
+++ b/exercises/pascals-triangle/test/test_pascals_triangle.c
@@ -14,7 +14,7 @@ static bool check(size_t count, size_t expected[][count], size_t ** result)
 {
    size_t i, j;
    for (i = 0; i < count; i++) {
-      for (j = 0; j < count; j++) {
+      for (j = 0; j <= i; j++) {
          if (expected[i][j] != result[i][j]) {
             return 0;
          }


### PR DESCRIPTION
I normally expect a sequence of arrays to have all the same size, but enforcing that by reading `size` elements from each row in the result feels overly restrictive.  It prohibits a solution that mallocs just big enough arrays for each row, and it prohibits a solution like the following without this modification:
``` c
static void build_rows(size_t **triangle, size_t size)
{
  if (!triangle) {
    return;
  }
  // Initialize the first row
  triangle[0][0] = 1;

  // Build each row from the values of the last row.
  for (size_t i = 1; i < size; ++i) {
    // First value
    triangle[i][0] = 0 + 1;
    // Pairwise summation of previous row for the middle values, ie. nextRow
    for (size_t j = 1; j < i; ++j) {
      triangle[i][j] = triangle[i - 1][j - 1] + triangle[i - 1][j];
    }
    // Last value
    triangle[i][i] = 1 + 0;
  }
}

static inline size_t sumto(int n) { return n * (n + 1) / 2; }

// Public API

size_t **create_triangle(int rows)
{
  size_t **triangle;

  // Bad Value
  if (rows < 0) {
    return NULL;
  }
  // Zero Triangle
  if (!rows) {
    triangle = calloc(1, sizeof(size_t *) + sizeof(size_t));
    if (!triangle) {
      return NULL;
    }
    // Cheat. 16 bytes. First machine word points to second machine word
    *triangle = (size_t *) (triangle + 1);
    return triangle;
  }
  // Normal modus operandi
  triangle = calloc(1, sizeof(size_t *) * rows + sizeof(size_t) * sumto(rows));
  if (!triangle) {
    return NULL;
  }
  size_t *row = (size_t *) (triangle + rows);
  // `triangle` to `triangle + rows` is the address range for our size_t pointers.
  // `row` to `row + sumto(rows)` is the address range for our size_t arrays.
  for (size_t i = 0; i < (size_t) rows; ++i) {
    row += i;
    *(triangle + i) = row;
  }
  build_rows(triangle, rows);
  return triangle;
}
```

I doubt such a solution is any faster than one that uses `sizeof(size_t) * (rows * (rows + 1))` memory, but such thinking is useful in memory constrained environments.

Anyway, I figure the point of the tests is to verify adherence to the specified behavior.  In this case, reading past the relevant data on the rows forces adherence to unspoken restrictions on the internal structure of the library's implementation.

If we are all of the same mind about this, my patch removes this bias from the test suite ;)