### PR TITLE
Improve consistency in square root naming

### DIFF
--- a/exercises/square-root/src/example.c
+++ b/exercises/square-root/src/example.c
@@ -1,6 +1,6 @@
 #include "square_root.h"
 
-uint16_t squareRoot(uint16_t radicand)
+uint16_t square_root(uint16_t radicand)
 {
    uint16_t result = 0;
    uint16_t bit = 1 << 14;

--- a/exercises/square-root/src/example.h
+++ b/exercises/square-root/src/example.h
@@ -3,6 +3,6 @@
 
 #include <stdint.h>
 
-uint16_t squareRoot(uint16_t radicand);
+uint16_t square_root(uint16_t radicand);
 
 #endif

--- a/exercises/square-root/test/test_square_root.c
+++ b/exercises/square-root/test/test_square_root.c
@@ -11,37 +11,37 @@ void tearDown(void)
 
 static void test_root_of_1(void)
 {
-   TEST_ASSERT_EQUAL_UINT16(1, squareRoot(1));
+   TEST_ASSERT_EQUAL_UINT16(1, square_root(1));
 }
 
 static void test_root_of_4(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT16(2, squareRoot(4));
+   TEST_ASSERT_EQUAL_UINT16(2, square_root(4));
 }
 
 static void test_root_of_25(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT16(5, squareRoot(25));
+   TEST_ASSERT_EQUAL_UINT16(5, square_root(25));
 }
 
 static void test_root_of_81(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT16(9, squareRoot(81));
+   TEST_ASSERT_EQUAL_UINT16(9, square_root(81));
 }
 
 static void test_root_of_196(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT16(14, squareRoot(196));
+   TEST_ASSERT_EQUAL_UINT16(14, square_root(196));
 }
 
 static void test_root_of_65025(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_EQUAL_UINT16(255, squareRoot(65025));
+   TEST_ASSERT_EQUAL_UINT16(255, square_root(65025));
 }
 
 int main(void)


### PR DESCRIPTION
Functions in other exercises use `snake_case` but square root used `camelCase`. This switches `squareRoot` to `square_root` to be consistent with other exercises.