### PR TITLE
Align tests toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/configlet
 bin/configlet.exe
+bin/canonical_data_syncer
 build/
 **/*.out
 **/*.o

--- a/exercises/acronym/.meta/tests.toml
+++ b/exercises/acronym/.meta/tests.toml
@@ -19,10 +19,10 @@
 "0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
 
 # consecutive delimiters
-"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+#"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
 
 # apostrophes
-"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+#"5118b4b1-4572-434c-8d57-5b762e57973e" = true
 
 # underscore emphasis
-"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true
+#"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true

--- a/exercises/all-your-base/.meta/tests.toml
+++ b/exercises/all-your-base/.meta/tests.toml
@@ -25,7 +25,7 @@
 "5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
 
 # empty list
-"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+"d68788f7-66dd-43f8-a543-f15b6d233f83" = false
 
 # single zero
 "5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
@@ -34,16 +34,16 @@
 "2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
 
 # leading zeros
-"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+#"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
 
 # input base is one
-"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+#"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
 
 # input base is zero
-"e21a693a-7a69-450b-b393-27415c26a016" = true
+#"e21a693a-7a69-450b-b393-27415c26a016" = true
 
 # input base is negative
-"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+#"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
 
 # negative digit
 "9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
@@ -52,13 +52,13 @@
 "232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
 
 # output base is one
-"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+#"14238f95-45da-41dc-95ce-18f860b30ad3" = true
 
 # output base is zero
-"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+#"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
 
 # output base is negative
-"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+#"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
 
 # both bases are negative
 "0e6c895d-8a5d-4868-a345-309d094cfe8d" = true

--- a/exercises/anagram/.meta/tests.toml
+++ b/exercises/anagram/.meta/tests.toml
@@ -4,7 +4,7 @@
 "dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
 
 # detects two anagrams
-"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+#"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
 
 # does not detect anagram subsets
 "a27558ee-9ba0-4552-96b1-ecf665b06556" = true
@@ -13,31 +13,31 @@
 "64cd4584-fc15-4781-b633-3d814c4941a4" = true
 
 # detects three anagrams
-"99c91beb-838f-4ccd-b123-935139917283" = true
+#"99c91beb-838f-4ccd-b123-935139917283" = true
 
 # detects multiple anagrams with different case
-"78487770-e258-4e1f-a646-8ece10950d90" = true
+#"78487770-e258-4e1f-a646-8ece10950d90" = true
 
 # does not detect non-anagrams with identical checksum
-"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+#"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
 
 # detects anagrams case-insensitively
 "9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
 
 # detects anagrams using case-insensitive subject
-"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+#"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
 
 # detects anagrams using case-insensitive possible matches
-"f367325c-78ec-411c-be76-e79047f4bd54" = true
+#"f367325c-78ec-411c-be76-e79047f4bd54" = true
 
 # does not detect an anagram if the original word is repeated
-"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+#"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
 
 # anagrams must use all letters exactly once
-"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+#"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
 
 # words are not anagrams of themselves (case-insensitive)
-"85757361-4535-45fd-ac0e-3810d40debc1" = true
+#"85757361-4535-45fd-ac0e-3810d40debc1" = true
 
 # words other than themselves can be anagrams
-"a0705568-628c-4b55-9798-82e4acde51ca" = true
+#"a0705568-628c-4b55-9798-82e4acde51ca" = true

--- a/exercises/atbash-cipher/.meta/tests.toml
+++ b/exercises/atbash-cipher/.meta/tests.toml
@@ -37,7 +37,7 @@
 "0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
 
 # decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+#"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
 
 # decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = true
+#"b34edf13-34c0-49b5-aa21-0768928000d5" = true

--- a/exercises/beer-song/.meta/tests.toml
+++ b/exercises/beer-song/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # first generic verse
-"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
+#"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
 
 # last generic verse
-"77299ca6-545e-4217-a9cc-606b342e0187" = true
+#"77299ca6-545e-4217-a9cc-606b342e0187" = true
 
 # verse with 2 bottles
-"102cbca0-b197-40fd-b548-e99609b06428" = true
+#"102cbca0-b197-40fd-b548-e99609b06428" = true
 
 # verse with 1 bottle
-"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
+#"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
 
 # verse with 0 bottles
-"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
+#"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
 
 # first two verses
-"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
+#"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
 
 # last three verses
-"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
+#"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
 
 # all verses
-"bc220626-126c-4e72-8df4-fddfc0c3e458" = true
+#"bc220626-126c-4e72-8df4-fddfc0c3e458" = true

--- a/exercises/binary-search/.meta/tests.toml
+++ b/exercises/binary-search/.meta/tests.toml
@@ -19,16 +19,16 @@
 "fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
 
 # identifies that a value is not included in the array
-"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
+#"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
 
 # a value smaller than the array's smallest value is not found
-"95d869ff-3daf-4c79-b622-6e805c675f97" = true
+#"95d869ff-3daf-4c79-b622-6e805c675f97" = true
 
 # a value larger than the array's largest value is not found
-"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
+#"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
 
 # nothing is found in an empty array
 "f439a0fa-cf42-4262-8ad1-64bf41ce566a" = true
 
 # nothing is found when the left and right bounds cross
-"2c353967-b56d-40b8-acff-ce43115eed64" = true
+#"2c353967-b56d-40b8-acff-ce43115eed64" = true

--- a/exercises/binary/.meta/tests.toml
+++ b/exercises/binary/.meta/tests.toml
@@ -31,7 +31,7 @@
 "44f7d8b1-ddc3-4751-8be3-700a538b421c" = true
 
 # a number containing a non-binary digit is invalid
-"c263a24d-6870-420f-b783-628feefd7b6e" = true
+#"c263a24d-6870-420f-b783-628feefd7b6e" = true
 
 # a number with trailing non-binary characters is invalid
 "8d81305b-0502-4a07-bfba-051c5526d7f2" = true

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -19,13 +19,13 @@
 "2a02716d-685b-4e2e-a804-2adaf281c01e" = true
 
 # talking forcefully
-"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+#"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
 
 # using acronyms in regular speech
-"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+#"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
 
 # forceful question
-"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+#"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
 
 # shouting numbers
 "a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
@@ -40,7 +40,7 @@
 "496143c8-1c31-4c01-8a08-88427af85c66" = true
 
 # shouting with no exclamation mark
-"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+#"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
 
 # statement containing question mark
 "aa8097cc-c548-4951-8856-14a404dd236a" = true
@@ -61,7 +61,7 @@
 "4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
 
 # multiple line question
-"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+#"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
 
 # starting with whitespace
 "5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true

--- a/exercises/complex-numbers/.meta/tests.toml
+++ b/exercises/complex-numbers/.meta/tests.toml
@@ -91,4 +91,4 @@
 "ed87f1bd-b187-45d6-8ece-7e331232c809" = true
 
 # Exponential of a number with real and imaginary part
-"08eedacc-5a95-44fc-8789-1547b27a8702" = true
+#"08eedacc-5a95-44fc-8789-1547b27a8702" = true

--- a/exercises/difference-of-squares/.meta/tests.toml
+++ b/exercises/difference-of-squares/.meta/tests.toml
@@ -1,7 +1,7 @@
 [canonical-tests]
 
 # square of sum 1
-"e46c542b-31fc-4506-bcae-6b62b3268537" = true
+#"e46c542b-31fc-4506-bcae-6b62b3268537" = true
 
 # square of sum 5
 "9b3f96cb-638d-41ee-99b7-b4f9c0622948" = true
@@ -10,7 +10,7 @@
 "54ba043f-3c35-4d43-86ff-3a41625d5e86" = true
 
 # sum of squares 1
-"01d84507-b03e-4238-9395-dd61d03074b5" = true
+#"01d84507-b03e-4238-9395-dd61d03074b5" = true
 
 # sum of squares 5
 "c93900cd-8cc2-4ca4-917b-dd3027023499" = true
@@ -19,7 +19,7 @@
 "94807386-73e4-4d9e-8dec-69eb135b19e4" = true
 
 # difference of squares 1
-"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
+#"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
 
 # difference of squares 5
 "005cb2bf-a0c8-46f3-ae25-924029f8b00b" = true

--- a/exercises/grade-school/.meta/tests.toml
+++ b/exercises/grade-school/.meta/tests.toml
@@ -10,7 +10,7 @@
 "75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
 
 # Roster returns an empty list if there are no students enrolled
-"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+#"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
 
 # Student names with grades are displayed in the same sorted roster
 "180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
@@ -19,4 +19,4 @@
 "1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
 
 # Grade returns an empty list if there are no students in that grade
-"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true
+#"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -7,13 +7,13 @@
 "54681314-eee2-439a-9db0-b0636c656156" = true
 
 # single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = true
+#"294479a3-a4c8-478f-8d63-6209815a827b" = true
 
 # long identical strands
 "9aed5f34-5693-4344-9b31-40c692fb5592" = true
 
 # long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+#"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
 
 # disallow first strand longer
 "919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
@@ -22,7 +22,7 @@
 "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
 
 # disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+#"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
 
 # disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true
+#"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,4 +1,4 @@
 [canonical-tests]
 
 # Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+#"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true

--- a/exercises/isogram/.meta/tests.toml
+++ b/exercises/isogram/.meta/tests.toml
@@ -22,16 +22,16 @@
 "14a4f3c1-3b47-4695-b645-53d328298942" = true
 
 # hypothetical isogrammic word with hyphen
-"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+#"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
 
 # hypothetical word with duplicated character following hyphen
-"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+#"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
 
 # isogram with duplicated hyphen
-"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+#"36b30e5c-173f-49c6-a515-93a3e825553f" = true
 
 # made-up name that is an isogram
-"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+#"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
 
 # duplicated character in the middle
 "5fc61048-d74e-48fd-bc34-abfc21552d4d" = true

--- a/exercises/largest-series-product/.meta/tests.toml
+++ b/exercises/largest-series-product/.meta/tests.toml
@@ -31,10 +31,10 @@
 "5d81aaf7-4f67-4125-bf33-11493cc7eab7" = true
 
 # reports 1 for empty string and empty product (0 span)
-"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = true
+#"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = true
 
 # reports 1 for nonempty string and empty product (0 span)
-"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = true
+#"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = true
 
 # rejects empty string and nonzero span
 "6d96c691-4374-4404-80ee-2ea8f3613dd4" = true
@@ -43,4 +43,4 @@
 "7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = true
 
 # rejects negative span
-"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = true
+#"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = true

--- a/exercises/leap/.meta/tests.toml
+++ b/exercises/leap/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # year not divisible by 4 in common year
-"6466b30d-519c-438e-935d-388224ab5223" = true
+#"6466b30d-519c-438e-935d-388224ab5223" = true
 
 # year divisible by 2, not divisible by 4 in common year
-"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+#"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
 
 # year divisible by 4, not divisible by 100 in leap year
-"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+#"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
 
 # year divisible by 4 and 5 is still a leap year
-"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+#"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
 
 # year divisible by 100, not divisible by 400 in common year
 "78a7848f-9667-4192-ae53-87b30c9a02dd" = true
 
 # year divisible by 100 but not by 3 is still not a leap year
-"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+#"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
 
 # year divisible by 400 in leap year
-"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+#"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
 
 # year divisible by 400 but not by 125 is still a leap year
-"57902c77-6fe9-40de-8302-587b5c27121e" = true
+#"57902c77-6fe9-40de-8302-587b5c27121e" = true
 
 # year divisible by 200, not divisible by 400 in common year
-"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true
+#"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true

--- a/exercises/list-ops/.meta/tests.toml
+++ b/exercises/list-ops/.meta/tests.toml
@@ -10,13 +10,13 @@
 "71dcf5eb-73ae-4a0e-b744-a52ee387922f" = true
 
 # empty list
-"28444355-201b-4af2-a2f6-5550227bde21" = true
+#"28444355-201b-4af2-a2f6-5550227bde21" = true
 
 # list of lists
-"331451c1-9573-42a1-9869-2d06e3b389a9" = true
+#"331451c1-9573-42a1-9869-2d06e3b389a9" = true
 
 # list of nested lists
-"d6ecd72c-197f-40c3-89a4-aa1f45827e09" = true
+#"d6ecd72c-197f-40c3-89a4-aa1f45827e09" = true
 
 # empty list
 "0524fba8-3e0f-4531-ad2b-f7a43da86a16" = true
@@ -61,4 +61,4 @@
 "fcc03d1e-42e0-4712-b689-d54ad761f360" = true
 
 # list of lists is not flattened
-"40872990-b5b8-4cb8-9085-d91fc0d05d26" = true
+#"40872990-b5b8-4cb8-9085-d91fc0d05d26" = true

--- a/exercises/luhn/.meta/tests.toml
+++ b/exercises/luhn/.meta/tests.toml
@@ -22,13 +22,13 @@
 "656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
 
 # invalid long number with an even remainder
-"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+#"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
 
 # valid number with an even number of digits
-"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+#"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
 
 # valid number with an odd number of spaces
-"ef081c06-a41f-4761-8492-385e13c8202d" = true
+#"ef081c06-a41f-4761-8492-385e13c8202d" = true
 
 # valid strings with a non-digit added at the end become invalid
 "bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
@@ -49,7 +49,7 @@
 "ab56fa80-5de8-4735-8a4a-14dae588663e" = true
 
 # using ascii value for non-doubled non-digit isn't allowed
-"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+#"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
 
 # using ascii value for doubled non-digit isn't allowed
-"f94cf191-a62f-4868-bc72-7253114aa157" = true
+#"f94cf191-a62f-4868-bc72-7253114aa157" = true

--- a/exercises/matching-brackets/.meta/tests.toml
+++ b/exercises/matching-brackets/.meta/tests.toml
@@ -19,7 +19,7 @@
 "754468e0-4696-4582-a30e-534d47d69756" = true
 
 # partially paired brackets
-"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+#"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
 
 # simple nested brackets
 "3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
@@ -40,10 +40,10 @@
 "a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
 
 # paired and incomplete brackets
-"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+#"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
 
 # too many closing brackets
-"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+#"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
 
 # math expression
 "99255f93-261b-4435-a352-02bdecc9bdf2" = true

--- a/exercises/meetup/.meta/tests.toml
+++ b/exercises/meetup/.meta/tests.toml
@@ -268,19 +268,19 @@
 "8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f" = true
 
 # last Sunday of March 2013
-"0b63e682-f429-4d19-9809-4a45bd0242dc" = true
+#"0b63e682-f429-4d19-9809-4a45bd0242dc" = true
 
 # last Sunday of April 2013
-"5232307e-d3e3-4afc-8ba6-4084ad987c00" = true
+#"5232307e-d3e3-4afc-8ba6-4084ad987c00" = true
 
 # last Wednesday of February 2012
-"0bbd48e8-9773-4e81-8e71-b9a51711e3c5" = true
+#"0bbd48e8-9773-4e81-8e71-b9a51711e3c5" = true
 
 # last Wednesday of December 2014
-"fe0936de-7eee-4a48-88dd-66c07ab1fefc" = true
+#"fe0936de-7eee-4a48-88dd-66c07ab1fefc" = true
 
 # last Sunday of February 2015
-"2ccf2488-aafc-4671-a24e-2b6effe1b0e2" = true
+#"2ccf2488-aafc-4671-a24e-2b6effe1b0e2" = true
 
 # first Friday of December 2012
 "00c3ce9f-cf36-4b70-90d8-92b32be6830e" = true

--- a/exercises/nth-prime/.meta/tests.toml
+++ b/exercises/nth-prime/.meta/tests.toml
@@ -10,7 +10,7 @@
 "56692534-781e-4e8c-b1f9-3e82c1640259" = true
 
 # big prime
-"fce1e979-0edb-412d-93aa-2c744e8f50ff" = true
+#"fce1e979-0edb-412d-93aa-2c744e8f50ff" = true
 
 # there is no zeroth prime
-"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = true
+#"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = true

--- a/exercises/nucleotide-count/.meta/tests.toml
+++ b/exercises/nucleotide-count/.meta/tests.toml
@@ -4,7 +4,7 @@
 "3e5c30a8-87e2-4845-a815-a49671ade970" = true
 
 # can count one nucleotide in single-character input
-"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
+#"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
 
 # strand with repeated nucleotide
 "eca0d565-ed8c-43e7-9033-6cefbf5115b5" = true

--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -28,4 +28,4 @@
 "938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
 
 # case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+#"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true

--- a/exercises/pascals-triangle/.meta/tests.toml
+++ b/exercises/pascals-triangle/.meta/tests.toml
@@ -16,10 +16,10 @@
 "565a0431-c797-417c-a2c8-2935e01ce306" = true
 
 # five rows
-"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
+#"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
 
 # six rows
-"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
+#"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
 
 # ten rows
-"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true
+#"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true

--- a/exercises/phone-number/.meta/tests.toml
+++ b/exercises/phone-number/.meta/tests.toml
@@ -1,7 +1,7 @@
 [canonical-tests]
 
 # cleans the number
-"79666dce-e0f1-46de-95a1-563802913c35" = true
+#"79666dce-e0f1-46de-95a1-563802913c35" = true
 
 # cleans numbers with dots
 "c360451f-549f-43e4-8aba-fdf6cb0bf83f" = true
@@ -13,10 +13,10 @@
 "598d8432-0659-4019-a78b-1c6a73691d21" = true
 
 # invalid when 11 digits does not start with a 1
-"57061c72-07b5-431f-9766-d97da7c4399d" = true
+#"57061c72-07b5-431f-9766-d97da7c4399d" = true
 
 # valid when 11 digits and starting with 1
-"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
+#"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
 
 # valid when 11 digits and starting with 1 even with punctuation
 "fa724fbf-054c-4d91-95da-f65ab5b6dbca" = true
@@ -31,25 +31,25 @@
 "4bd97d90-52fd-45d3-b0db-06ab95b1244e" = true
 
 # invalid if area code starts with 0
-"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
+#"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
 
 # invalid if area code starts with 1
-"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
+#"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
 
 # invalid if exchange code starts with 0
-"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
+#"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
 
 # invalid if exchange code starts with 1
-"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
+#"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
 
 # invalid if area code starts with 0 on valid 11-digit number
-"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
+#"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
 
 # invalid if area code starts with 1 on valid 11-digit number
-"3f809d37-40f3-44b5-ad90-535838b1a816" = true
+#"3f809d37-40f3-44b5-ad90-535838b1a816" = true
 
 # invalid if exchange code starts with 0 on valid 11-digit number
-"e08e5532-d621-40d4-b0cc-96c159276b65" = true
+#"e08e5532-d621-40d4-b0cc-96c159276b65" = true
 
 # invalid if exchange code starts with 1 on valid 11-digit number
-"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true
+#"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true

--- a/exercises/queen-attack/.meta/tests.toml
+++ b/exercises/queen-attack/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # queen with a valid position
-"3ac4f735-d36c-44c4-a3e2-316f79704203" = true
+#"3ac4f735-d36c-44c4-a3e2-316f79704203" = true
 
 # queen must have positive row
-"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = true
+#"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = true
 
 # queen must have row on board
-"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = true
+#"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = true
 
 # queen must have positive column
-"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = true
+#"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = true
 
 # queen must have column on board
-"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = true
+#"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = true
 
 # can not attack
 "33ae4113-d237-42ee-bac1-e1e699c0c007" = true

--- a/exercises/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/rail-fence-cipher/.meta/tests.toml
@@ -13,7 +13,7 @@
 "cd525b17-ec34-45ef-8f0e-4f27c24a7127" = true
 
 # decode with five rails
-"dd7b4a98-1a52-4e5c-9499-cbb117833507" = true
+#"dd7b4a98-1a52-4e5c-9499-cbb117833507" = true
 
 # decode with six rails
-"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = true
+#"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = true

--- a/exercises/raindrops/.meta/tests.toml
+++ b/exercises/raindrops/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+#"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
 
 # the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+#"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
 
 # the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+#"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
 
 # the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+#"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
 
 # the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+#"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
 
 # 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+#"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
 
 # the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+#"0dd66175-e3e2-47fc-8750-d01739856671" = true
 
 # the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+#"022c44d3-2182-4471-95d7-c575af225c96" = true
 
 # the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+#"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
 
 # the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+#"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
 
 # the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+#"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
 
 # the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+#"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
 
 # the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+#"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
 
 # the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+#"bdf061de-8564-4899-a843-14b48b722789" = true
 
 # the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+#"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
 
 # the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+#"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
 
 # the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+#"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
 
 # the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
+#"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true

--- a/exercises/react/.meta/tests.toml
+++ b/exercises/react/.meta/tests.toml
@@ -25,19 +25,19 @@
 "9e5cb3a4-78e5-4290-80f8-a78612c52db2" = true
 
 # callbacks do not report already reported values
-"ada17cb6-7332-448a-b934-e3d7495c13d3" = true
+#"ada17cb6-7332-448a-b934-e3d7495c13d3" = true
 
 # callbacks can fire from multiple cells
-"ac271900-ea5c-461c-9add-eeebcb8c03e5" = true
+#"ac271900-ea5c-461c-9add-eeebcb8c03e5" = true
 
 # callbacks can be added and removed
 "95a82dcc-8280-4de3-a4cd-4f19a84e3d6f" = true
 
 # removing a callback multiple times doesn't interfere with other callbacks
-"f2a7b445-f783-4e0e-8393-469ab4915f2a" = true
+#"f2a7b445-f783-4e0e-8393-469ab4915f2a" = true
 
 # callbacks should only be called once even if multiple dependencies change
-"daf6feca-09e0-4ce5-801d-770ddfe1c268" = true
+#"daf6feca-09e0-4ce5-801d-770ddfe1c268" = true
 
 # callbacks should not be called if dependencies change but output value doesn't change
 "9a5b159f-b7aa-4729-807e-f1c38a46d377" = true

--- a/exercises/rna-transcription/.meta/tests.toml
+++ b/exercises/rna-transcription/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # Empty RNA sequence
-"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+#"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
 
 # RNA complement of cytosine is guanine
-"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+#"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
 
 # RNA complement of guanine is cytosine
-"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+#"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
 
 # RNA complement of thymine is adenine
-"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+#"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
 
 # RNA complement of adenine is uracil
-"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+#"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
 
 # RNA complement
-"79ed2757-f018-4f47-a1d7-34a559392dbf" = true
+#"79ed2757-f018-4f47-a1d7-34a559392dbf" = true

--- a/exercises/robot-simulator/.meta/tests.toml
+++ b/exercises/robot-simulator/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # at origin facing north
-"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
+#"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
 
 # at negative position facing south
-"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
+#"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
 
 # changes north to east
 "8cbd0086-6392-4680-b9b9-73cf491e67e5" = true
 
 # changes east to south
-"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
+#"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
 
 # changes south to west
-"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
+#"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
 
 # changes west to north
-"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
+#"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
 
 # changes north to west
-"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
+#"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
 
 # changes west to south
-"da33d734-831f-445c-9907-d66d7d2a92e2" = true
+#"da33d734-831f-445c-9907-d66d7d2a92e2" = true
 
 # changes south to east
-"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
+#"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
 
 # changes east to north
-"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
+#"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
 
 # facing north increments Y
-"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
+#"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
 
 # facing south decrements Y
-"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
+#"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
 
 # facing east increments X
-"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
+#"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
 
 # facing west decrements X
-"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
+#"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
 
 # moving east and north from README
-"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
+#"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
 
 # moving west and north
-"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
+#"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
 
 # moving west and south
-"3e466bf6-20ab-4d79-8b51-264165182fca" = true
+#"3e466bf6-20ab-4d79-8b51-264165182fca" = true
 
 # moving east and north
-"41f0bb96-c617-4e6b-acff-a4b279d44514" = true
+#"41f0bb96-c617-4e6b-acff-a4b279d44514" = true

--- a/exercises/roman-numerals/.meta/tests.toml
+++ b/exercises/roman-numerals/.meta/tests.toml
@@ -22,7 +22,7 @@
 "ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
 
 # 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+#"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
 
 # 48 is not 50 - 2 but rather 40 + 8
 "a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
@@ -31,28 +31,28 @@
 "607ead62-23d6-4c11-a396-ef821e2e5f75" = true
 
 # 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+#"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
 
 # 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+#"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
 
 # 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+#"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
 
 # 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+#"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
 
 # 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+#"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
 
 # 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+#"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
 
 # 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+#"432de891-7fd6-4748-a7f6-156082eeca2f" = true
 
 # 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+#"e6de6d24-f668-41c0-88d7-889c0254d173" = true
 
 # 3000 is three M's
 "bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true

--- a/exercises/series/.meta/tests.toml
+++ b/exercises/series/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # slices of one from one
-"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = true
+#"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = true
 
 # slices of one from two
-"3143b71d-f6a5-4221-aeae-619f906244d2" = true
+#"3143b71d-f6a5-4221-aeae-619f906244d2" = true
 
 # slices of two
 "dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = true
 
 # slices of two overlap
-"19bbea47-c987-4e11-a7d1-e103442adf86" = true
+#"19bbea47-c987-4e11-a7d1-e103442adf86" = true
 
 # slices can include duplicates
-"8e17148d-ba0a-4007-a07f-d7f87015d84c" = true
+#"8e17148d-ba0a-4007-a07f-d7f87015d84c" = true
 
 # slices of a long series
-"bd5b085e-f612-4f81-97a8-6314258278b0" = true
+#"bd5b085e-f612-4f81-97a8-6314258278b0" = true
 
 # slice length is too large
-"6d235d85-46cf-4fae-9955-14b6efef27cd" = true
+#"6d235d85-46cf-4fae-9955-14b6efef27cd" = true
 
 # slice length cannot be zero
-"d34004ad-8765-4c09-8ba1-ada8ce776806" = true
+#"d34004ad-8765-4c09-8ba1-ada8ce776806" = true
 
 # slice length cannot be negative
-"10ab822d-8410-470a-a85d-23fbeb549e54" = true
+#"10ab822d-8410-470a-a85d-23fbeb549e54" = true
 
 # empty series is invalid
-"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = true
+#"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = true

--- a/exercises/space-age/.meta/tests.toml
+++ b/exercises/space-age/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+#"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
 
 # age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+#"ca20c4e9-6054-458c-9312-79679ffab40b" = true
 
 # age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+#"502c6529-fd1b-41d3-8fab-65e03082b024" = true
 
 # age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+#"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
 
 # age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+#"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
 
 # age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+#"8469b332-7837-4ada-b27c-00ee043ebcad" = true
 
 # age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = true
+#"999354c1-76f8-4bb5-a672-f317b6436743" = true
 
 # age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = true
+#"80096d30-a0d4-4449-903e-a381178355d8" = true

--- a/exercises/sum-of-multiples/.meta/tests.toml
+++ b/exercises/sum-of-multiples/.meta/tests.toml
@@ -1,49 +1,49 @@
 [canonical-tests]
 
 # no multiples within limit
-"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
+#"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
 
 # one factor has multiples within limit
-"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
+#"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
 
 # more than one multiple within limit
-"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
+#"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
 
 # more than one factor with multiples within limit
-"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
+#"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
 
 # each multiple is only counted once
-"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
+#"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
 
 # a much larger limit
-"28c4b267-c980-4054-93e9-07723db615ac" = true
+#"28c4b267-c980-4054-93e9-07723db615ac" = true
 
 # three factors
-"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
+#"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
 
 # factors not relatively prime
-"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
+#"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
 
 # some pairs of factors relatively prime and some not
-"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
+#"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
 
 # one factor is a multiple of another
-"624fdade-6ffb-400e-8472-456a38c171c0" = true
+#"624fdade-6ffb-400e-8472-456a38c171c0" = true
 
 # much larger factors
-"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
+#"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
 
 # all numbers are multiples of 1
-"41093673-acbd-482c-ab80-d00a0cbedecd" = true
+#"41093673-acbd-482c-ab80-d00a0cbedecd" = true
 
 # no factors means an empty sum
-"1730453b-baaa-438e-a9c2-d754497b2a76" = true
+#"1730453b-baaa-438e-a9c2-d754497b2a76" = true
 
 # the only multiple of 0 is 0
-"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
+#"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
 
 # the factor 0 does not affect the sum of multiples of other factors
-"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
+#"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
 
 # solutions using include-exclude must extend to cardinality greater than 3
-"17053ba9-112f-4ac0-aadb-0519dd836342" = true
+#"17053ba9-112f-4ac0-aadb-0519dd836342" = true

--- a/exercises/triangle/.meta/tests.toml
+++ b/exercises/triangle/.meta/tests.toml
@@ -7,7 +7,7 @@
 "33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = true
 
 # no sides are equal
-"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = true
+#"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = true
 
 # all zero sides is not a triangle
 "16e8ceb0-eadb-46d1-b892-c50327479251" = true
@@ -31,13 +31,13 @@
 "840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = true
 
 # first triangle inequality violation
-"2eba0cfb-6c65-4c40-8146-30b608905eae" = true
+#"2eba0cfb-6c65-4c40-8146-30b608905eae" = true
 
 # second triangle inequality violation
-"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = true
+#"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = true
 
 # third triangle inequality violation
-"90efb0c7-72bb-4514-b320-3a3892e278ff" = true
+#"90efb0c7-72bb-4514-b320-3a3892e278ff" = true
 
 # sides may be floats
 "adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = true
@@ -52,7 +52,7 @@
 "c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = true
 
 # may not violate triangle inequality
-"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = true
+#"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = true
 
 # sides may be floats
 "26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = true

--- a/exercises/word-count/.meta/tests.toml
+++ b/exercises/word-count/.meta/tests.toml
@@ -31,10 +31,10 @@
 "be72af2b-8afe-4337-b151-b297202e4a7b" = true
 
 # substrings from the beginning
-"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+#"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
 
 # multiple spaces not detected as a word
-"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+#"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
 
 # alternating word separators not detected as a word
-"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true
+#"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true

--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -1,7 +1,7 @@
 [canonical-tests]
 
 # just a number
-"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
+#"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
 
 # addition
 "bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
@@ -52,19 +52,19 @@
 "8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
 
 # reject problem missing an operand
-"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
+#"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
 
 # reject problem with no operands or operators
-"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
+#"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
 
 # reject two operations in a row
-"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
+#"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
 
 # reject two numbers in a row
-"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
+#"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
 
 # reject postfix notation
-"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
+#"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
 
 # reject prefix notation
-"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true
+#"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true


### PR DESCRIPTION
Erik has kindly added the `tests.toml` files for each exercise in #487. As per Erik's PR message, the added files assume that all tests are implemented and up to date

I am adjusting those files to align with the reality of the tests.

In cases where a test is unimplemented, I have commented the related line in the `tests.toml` rather than removing it. This is intended to make it easier to add it back again if the missing test is added soon after.

In cases where a test is implemented but is an old version I take the same above approach on the basis that the test _as currently specified_ is not present (as advised by @sleeplessByte https://exercism-team.slack.com/archives/CAQP7JL3T/p1602446417053400?thread_ts=1602446259.052700&cid=CAQP7JL3T). I am being fairly strict here, applying this even if only the test name needs adjusting.

Tests that are not expected to be implemented (e.g. are not relevant in C) are set to `false`

This does NOT account for tests that are implemented but have been _removed_ from the specification. These will need to be identified and potentially removed at a later stage.