### PR TITLE
palindrome-products: make tests check factors that are in different orders

### DIFF
--- a/exercises/palindrome-products/test/test_palindrome_products.c
+++ b/exercises/palindrome-products/test/test_palindrome_products.c
@@ -28,7 +28,7 @@ static bool factor_t_are_equal(const factor_t * const f1,
                                const factor_t * const f2)
 {
    return ((f1->factor_a == f2->factor_a) && (f1->factor_b == f2->factor_b)) ||
-       ((f1->factor_a == f2->factor_b) && (f1->factor_a == f2->factor_b));
+       ((f1->factor_a == f2->factor_b) && (f1->factor_b == f2->factor_a));
 }
 
 /* contains_factor checks if the `factor` variable is stored


### PR DESCRIPTION
Test typo meant the same expression on both sides of the '&&', meaning that only one ordering of factors would be allowed.

Previous implementation did correctly not let failing implementation pass but would fail a subset of passing implementations due to enforcing factor ordering where none is needed.