### PR TITLE
pangram: Update to most recent canonical data

### DIFF
--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -28,4 +28,4 @@
 "938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
 
 # case insensitive
-#"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true

--- a/exercises/pangram/test/test_pangram.c
+++ b/exercises/pangram/test/test_pangram.c
@@ -22,7 +22,7 @@ static void test_empty_sentence(void)
    TEST_ASSERT_FALSE(is_pangram(sentence));
 }
 
-static void test_perfect_lowercase_pangram(void)
+static void test_perfect_lower_case(void)
 {
    TEST_IGNORE();
    const char sentence[] = "abcdefghijklmnopqrstuvwxyz";
@@ -30,7 +30,7 @@ static void test_perfect_lowercase_pangram(void)
    TEST_ASSERT_TRUE(is_pangram(sentence));
 }
 
-static void test_lowercase_pangram(void)
+static void test_only_lower_case(void)
 {
    TEST_IGNORE();
    const char sentence[] = "the quick brown fox jumps over the lazy dog";
@@ -38,7 +38,7 @@ static void test_lowercase_pangram(void)
    TEST_ASSERT_TRUE(is_pangram(sentence));
 }
 
-static void test_missing_character_x(void)
+static void test_missing_letter_x(void)
 {
    TEST_IGNORE();
    const char sentence[] =
@@ -47,7 +47,7 @@ static void test_missing_character_x(void)
    TEST_ASSERT_FALSE(is_pangram(sentence));
 }
 
-static void test_another_missing_h(void)
+static void test_missing_letter_h(void)
 {
    TEST_IGNORE();
    const char sentence[] = "five boxing wizards jump quickly at it";
@@ -55,7 +55,7 @@ static void test_another_missing_h(void)
    TEST_ASSERT_FALSE(is_pangram(sentence));
 }
 
-static void test_pangram_with_underscores(void)
+static void test_with_underscores(void)
 {
    TEST_IGNORE();
    const char sentence[] = "the_quick_brown_fox_jumps_over_the_lazy_dog";
@@ -63,7 +63,7 @@ static void test_pangram_with_underscores(void)
    TEST_ASSERT_TRUE(is_pangram(sentence));
 }
 
-static void test_pangram_with_numbers(void)
+static void test_with_numbers(void)
 {
    TEST_IGNORE();
    const char sentence[] = "the 1 quick brown fox jumps over the 2 lazy dogs";
@@ -87,7 +87,7 @@ static void test_mixed_case_and_punctuation(void)
    TEST_ASSERT_TRUE(is_pangram(sentence));
 }
 
-static void test_upper_and_lower_case_of_same_character(void)
+static void test_case_insensitive(void)
 {
    TEST_IGNORE();
    const char sentence[] = "the quick brown fox jumps over with lazy FX";
@@ -101,15 +101,15 @@ int main(void)
 
    RUN_TEST(test_null);
    RUN_TEST(test_empty_sentence);
-   RUN_TEST(test_perfect_lowercase_pangram);
-   RUN_TEST(test_lowercase_pangram);
-   RUN_TEST(test_missing_character_x);
-   RUN_TEST(test_another_missing_h);
-   RUN_TEST(test_pangram_with_underscores);
-   RUN_TEST(test_pangram_with_numbers);
+   RUN_TEST(test_perfect_lower_case);
+   RUN_TEST(test_only_lower_case);
+   RUN_TEST(test_missing_letter_x);
+   RUN_TEST(test_missing_letter_h);
+   RUN_TEST(test_with_underscores);
+   RUN_TEST(test_with_numbers);
    RUN_TEST(test_missing_letters_replaced_by_numbers);
    RUN_TEST(test_mixed_case_and_punctuation);
-   RUN_TEST(test_upper_and_lower_case_of_same_character);
+   RUN_TEST(test_case_insensitive);
 
    return UnityEnd();
 }


### PR DESCRIPTION
Resolves #515 

- Updates names for existing test cases to align closer to what's in canonical data
- There was also a test marked as missing but it looks like that test already exists so I've uncommented that line in `.meta/tests.toml`

Reference: [pangram `canonical-data.json`](https://github.com/exercism/problem-specifications/blob/master/exercises/pangram/canonical-data.json) 