### PR TITLE
isogram: Sync to latest canonical exercise data

### DIFF
--- a/exercises/isogram/.meta/tests.toml
+++ b/exercises/isogram/.meta/tests.toml
@@ -22,16 +22,16 @@
 "14a4f3c1-3b47-4695-b645-53d328298942" = true
 
 # hypothetical isogrammic word with hyphen
-#"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
 
 # hypothetical word with duplicated character following hyphen
-#"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
 
 # isogram with duplicated hyphen
-#"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+"36b30e5c-173f-49c6-a515-93a3e825553f" = true
 
 # made-up name that is an isogram
-#"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
 
 # duplicated character in the middle
 "5fc61048-d74e-48fd-bc34-abfc21552d4d" = true

--- a/exercises/isogram/test/test_isogram.c
+++ b/exercises/isogram/test/test_isogram.c
@@ -21,67 +21,67 @@ static void test_null(void)
    TEST_ASSERT_FALSE(is_isogram(NULL));
 }
 
-static void test_lower_case_only(void)
+static void test_isogram_with_only_lower_case_characters(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_TRUE(is_isogram("isogram"));
 }
 
-static void test_duplicated_letter(void)
+static void test_word_with_one_duplicated_character(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("eleven"));
 }
 
-static void test_duplicated_letter_from_end_of_alphabet(void)
+static void test_word_with_one_duplicated_character_from_end_of_alphabet(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("zzyzx"));
 }
 
-static void test_longest_known_isogram(void)
+static void test_longest_reported_english_isogram(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_TRUE(is_isogram("subdermatoglyphic"));
 }
 
-static void test_duplicated_letter_mixed_case(void)
+static void test_word_with_duplicated_letter_in_mixed_case(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("Alphabet"));
 }
 
-static void test_duplicated_letter_mixed_case_lowercase_first(void)
+static void test_word_with_duplicated_letter_in_mixed_case_lowercase_first(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("alphAbet"));
 }
 
-static void test_non_letter_char(void)
+static void test_hypothetical_isogrammic_word_with_hyphen(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_TRUE(is_isogram("thumbscrew-japingly"));
 }
 
-static void test_duplicated_letter_following_non_letter_char(void)
+static void test_hypothetical_word_with_duplicated_character_following_hyphen(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("thumbscrew-jappingly"));
 }
 
-static void test_duplicated_non_letter_char(void)
+static void test_isogram_with_duplicated_hyphen(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_TRUE(is_isogram("six-year-old"));
 }
 
-static void test_multiple_whitespace(void)
+static void test_made_up_name_that_is_an_isogram(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_TRUE(is_isogram("Emily Jung Schwartzkopf"));
 }
 
-static void test_duplicated_letter_within_word(void)
+static void test_duplicated_character_in_the_middle(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("accentor"));
@@ -99,17 +99,17 @@ int main(void)
 
    RUN_TEST(test_empty_string);
    RUN_TEST(test_null);
-   RUN_TEST(test_lower_case_only);
-   RUN_TEST(test_duplicated_letter);
-   RUN_TEST(test_duplicated_letter_from_end_of_alphabet);
-   RUN_TEST(test_longest_known_isogram);
-   RUN_TEST(test_duplicated_letter_mixed_case);
-   RUN_TEST(test_duplicated_letter_mixed_case_lowercase_first);
-   RUN_TEST(test_non_letter_char);
-   RUN_TEST(test_duplicated_letter_following_non_letter_char);
-   RUN_TEST(test_duplicated_non_letter_char);
-   RUN_TEST(test_multiple_whitespace);
-   RUN_TEST(test_duplicated_letter_within_word);
+   RUN_TEST(test_isogram_with_only_lower_case_characters);
+   RUN_TEST(test_word_with_one_duplicated_character);
+   RUN_TEST(test_word_with_one_duplicated_character_from_end_of_alphabet);
+   RUN_TEST(test_longest_reported_english_isogram);
+   RUN_TEST(test_word_with_duplicated_letter_in_mixed_case);
+   RUN_TEST(test_word_with_duplicated_letter_in_mixed_case_lowercase_first);
+   RUN_TEST(test_hypothetical_isogrammic_word_with_hyphen);
+   RUN_TEST(test_hypothetical_word_with_duplicated_character_following_hyphen);
+   RUN_TEST(test_isogram_with_duplicated_hyphen);
+   RUN_TEST(test_made_up_name_that_is_an_isogram);
+   RUN_TEST(test_duplicated_character_in_the_middle);
    RUN_TEST(test_same_first_and_last_characters);
 
    return UnityEnd();

--- a/exercises/isogram/test/test_isogram.c
+++ b/exercises/isogram/test/test_isogram.c
@@ -63,7 +63,8 @@ static void test_hypothetical_isogrammic_word_with_hyphen(void)
    TEST_ASSERT_TRUE(is_isogram("thumbscrew-japingly"));
 }
 
-static void test_hypothetical_word_with_duplicated_character_following_hyphen(void)
+static void
+test_hypothetical_word_with_duplicated_character_following_hyphen(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_FALSE(is_isogram("thumbscrew-jappingly"));


### PR DESCRIPTION
Resolves #506 

- Updates names for existing test cases to align closer to what's in canonical data
- Unskip tests in `.meta/tests.toml` that are already accounted for

Reference: [isogram `canonical-data.json`](https://github.com/exercism/problem-specifications/blob/master/exercises/isogram/canonical-data.json)

Test output with `TEST_IGNORE`s in `test_isogram.c` commented out:

```sh
$ make test
Compiling tests.out
test/test_isogram.c:100:test_empty_string:PASS
test/test_isogram.c:101:test_null:PASS
test/test_isogram.c:102:test_isogram_with_only_lower_case_characters:PASS
test/test_isogram.c:103:test_word_with_one_duplicated_character:PASS
test/test_isogram.c:104:test_word_with_one_duplicated_character_from_end_of_alphabet:PASS
test/test_isogram.c:105:test_longest_reported_english_isogram:PASS
test/test_isogram.c:106:test_word_with_duplicated_letter_in_mixed_case:PASS
test/test_isogram.c:107:test_word_with_duplicated_letter_in_mixed_case_lowercase_first:PASS
test/test_isogram.c:108:test_hypothetical_isogrammic_word_with_hyphen:PASS
test/test_isogram.c:109:test_hypothetical_word_with_duplicated_character_following_hyphen:PASS
test/test_isogram.c:110:test_isogram_with_duplicated_hyphen:PASS
test/test_isogram.c:111:test_made_up_name_that_is_an_isogram:PASS
test/test_isogram.c:112:test_duplicated_character_in_the_middle:PASS
test/test_isogram.c:113:test_same_first_and_last_characters:PASS

-----------------------
14 Tests 0 Failures 0 Ignored
OK
```