### PR TITLE
beer-song: align with specification per #497

### DIFF
--- a/exercises/beer-song/.meta/tests.toml
+++ b/exercises/beer-song/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # first generic verse
-#"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
+"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
 
 # last generic verse
-#"77299ca6-545e-4217-a9cc-606b342e0187" = true
+"77299ca6-545e-4217-a9cc-606b342e0187" = true
 
 # verse with 2 bottles
-#"102cbca0-b197-40fd-b548-e99609b06428" = true
+"102cbca0-b197-40fd-b548-e99609b06428" = true
 
 # verse with 1 bottle
-#"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
+"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
 
 # verse with 0 bottles
-#"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
+"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
 
 # first two verses
-#"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
+"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
 
 # last three verses
-#"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
+"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
 
 # all verses
-#"bc220626-126c-4e72-8df4-fddfc0c3e458" = true
+"bc220626-126c-4e72-8df4-fddfc0c3e458" = false

--- a/exercises/beer-song/src/beer_song.h
+++ b/exercises/beer-song/src/beer_song.h
@@ -1,8 +1,6 @@
 #ifndef BEER_SONG_H
 #define BEER_SONG_H
 
-void verse(char *buffer, unsigned int verse_number);
-void sing(char *buffer, unsigned int starting_verse_number,
-          unsigned int ending_verse_number);
+void recite(unsigned int start_bottles, unsigned int take_down, char *buffer);
 
 #endif

--- a/exercises/beer-song/src/example.c
+++ b/exercises/beer-song/src/example.c
@@ -2,49 +2,42 @@
 #include <stdio.h>
 #include <string.h>
 
-static unsigned int get_verse(char *buffer, unsigned int verse_number)
+static unsigned int get_verse(unsigned int bottles, char *buffer)
 {
    unsigned int bytes_written = 0;
 
-   if (verse_number == 0) {
+   if (bottles == 0) {
       bytes_written =
           sprintf(buffer,
                   "No more bottles of beer on the wall, no more bottles of beer.\n"
                   "Go to the store and buy some more, 99 bottles of beer on the wall.\n");
-   } else if (verse_number == 1) {
+   } else if (bottles == 1) {
       bytes_written =
           sprintf(buffer,
                   "1 bottle of beer on the wall, 1 bottle of beer.\n"
                   "Take it down and pass it around, no more bottles of beer on the wall.\n");
-   } else if (verse_number == 2) {
+   } else if (bottles == 2) {
       bytes_written =
           sprintf(buffer,
                   "2 bottles of beer on the wall, 2 bottles of beer.\n"
                   "Take one down and pass it around, 1 bottle of beer on the wall.\n");
-   } else if (verse_number <= 99) {
+   } else if (bottles <= 99) {
       bytes_written =
           sprintf(buffer,
                   "%u bottles of beer on the wall, %u bottles of beer.\n"
                   "Take one down and pass it around, %u bottles of beer on the wall.\n",
-                  verse_number, verse_number, verse_number - 1);
+                  bottles, bottles, bottles - 1);
    }
 
    return bytes_written;
 }
 
-void verse(char *buffer, unsigned int verse_number)
-{
-   (void)get_verse(buffer, verse_number);
-}
-
-void sing(char *buffer, unsigned int starting_verse_number,
-          unsigned int ending_verse_number)
+void recite(unsigned int start_bottles, unsigned int take_down, char *buffer)
 {
    char *current_position = buffer;
 
-   for (unsigned int i = starting_verse_number + 1; i > ending_verse_number;
-        i--) {
-      current_position += get_verse(current_position, i - 1);
+   while (take_down-- > 0) {
+      current_position += get_verse(start_bottles--, current_position);
       strcpy(current_position, "\n");
       current_position++;
    }

--- a/exercises/beer-song/src/example.h
+++ b/exercises/beer-song/src/example.h
@@ -1,8 +1,6 @@
 #ifndef BEER_SONG_H
 #define BEER_SONG_H
 
-void verse(char *buffer, unsigned int verse_number);
-void sing(char *buffer, unsigned int starting_verse_number,
-          unsigned int ending_verse_number);
+void recite(unsigned int start_bottles, unsigned int take_down, char *buffer);
 
 #endif

--- a/exercises/beer-song/test/test_beer_song.c
+++ b/exercises/beer-song/test/test_beer_song.c
@@ -11,18 +11,29 @@ void tearDown(void)
 {
 }
 
-static void test_handles_arbitrary_verse(void)
+static void test_first_generic_verse(void)
 {
    char response[BUFFER_SIZE];
    const char expected[BUFFER_SIZE] =
-       "84 bottles of beer on the wall, 84 bottles of beer.\n"
-       "Take one down and pass it around, 83 bottles of beer on the wall.\n";
+       "99 bottles of beer on the wall, 99 bottles of beer.\n"
+       "Take one down and pass it around, 98 bottles of beer on the wall.\n";
 
-   verse(response, 84);
+   recite(99, 1, response);
    TEST_ASSERT_EQUAL_STRING(expected, response);
 }
 
-static void test_handles_2_bottles(void)
+static void test_last_generic_verse(void)
+{
+   char response[BUFFER_SIZE];
+   const char expected[BUFFER_SIZE] =
+       "3 bottles of beer on the wall, 3 bottles of beer.\n"
+       "Take one down and pass it around, 2 bottles of beer on the wall.\n";
+
+   recite(3, 1, response);
+   TEST_ASSERT_EQUAL_STRING(expected, response);
+}
+
+static void test_verse_with_2_bottles(void)
 {
    TEST_IGNORE();               // delete this line to run test
    char response[BUFFER_SIZE];
@@ -30,11 +41,11 @@ static void test_handles_2_bottles(void)
        "2 bottles of beer on the wall, 2 bottles of beer.\n"
        "Take one down and pass it around, 1 bottle of beer on the wall.\n";
 
-   verse(response, 2);
+   recite(2, 1, response);
    TEST_ASSERT_EQUAL_STRING(expected, response);
 }
 
-static void test_handles_1_bottle(void)
+static void test_verse_with_1_bottle(void)
 {
    TEST_IGNORE();
    char response[BUFFER_SIZE];
@@ -42,11 +53,11 @@ static void test_handles_1_bottle(void)
        "1 bottle of beer on the wall, 1 bottle of beer.\n"
        "Take it down and pass it around, no more bottles of beer on the wall.\n";
 
-   verse(response, 1);
+   recite(1, 1, response);
    TEST_ASSERT_EQUAL_STRING(expected, response);
 }
 
-static void test_handles_0_bottles(void)
+static void test_verse_with_0_bottles(void)
 {
    TEST_IGNORE();
    char response[BUFFER_SIZE];
@@ -54,36 +65,30 @@ static void test_handles_0_bottles(void)
        "No more bottles of beer on the wall, no more bottles of beer.\n"
        "Go to the store and buy some more, 99 bottles of beer on the wall.\n";
 
-   verse(response, 0);
+   recite(0, 1, response);
    TEST_ASSERT_EQUAL_STRING(expected, response);
 }
 
-static void test_sings_several_verses(void)
+static void test_first_two_verses(void)
 {
    TEST_IGNORE();
    char response[BUFFER_SIZE];
    const char expected[BUFFER_SIZE] =
-       "8 bottles of beer on the wall, 8 bottles of beer.\n"
-       "Take one down and pass it around, 7 bottles of beer on the wall.\n"
+       "99 bottles of beer on the wall, 99 bottles of beer.\n"
+       "Take one down and pass it around, 98 bottles of beer on the wall.\n"
        "\n"
-       "7 bottles of beer on the wall, 7 bottles of beer.\n"
-       "Take one down and pass it around, 6 bottles of beer on the wall.\n"
-       "\n"
-       "6 bottles of beer on the wall, 6 bottles of beer.\n"
-       "Take one down and pass it around, 5 bottles of beer on the wall.\n";
+       "98 bottles of beer on the wall, 98 bottles of beer.\n"
+       "Take one down and pass it around, 97 bottles of beer on the wall.\n";
 
-   sing(response, 8, 6);
+   recite(99, 2, response);
    TEST_ASSERT_EQUAL_STRING(expected, response);
 }
 
-static void test_sings_the_last_4_verses(void)
+static void test_last_three_verses(void)
 {
    TEST_IGNORE();
    char response[BUFFER_SIZE];
    const char expected[BUFFER_SIZE] =
-       "3 bottles of beer on the wall, 3 bottles of beer.\n"
-       "Take one down and pass it around, 2 bottles of beer on the wall.\n"
-       "\n"
        "2 bottles of beer on the wall, 2 bottles of beer.\n"
        "Take one down and pass it around, 1 bottle of beer on the wall.\n"
        "\n"
@@ -93,7 +98,7 @@ static void test_sings_the_last_4_verses(void)
        "No more bottles of beer on the wall, no more bottles of beer.\n"
        "Go to the store and buy some more, 99 bottles of beer on the wall.\n";
 
-   sing(response, 3, 0);
+   recite(2, 3, response);
    TEST_ASSERT_EQUAL_STRING(expected, response);
 }
 
@@ -101,12 +106,13 @@ int main(void)
 {
    UnityBegin("test/test_beer_song.c");
 
-   RUN_TEST(test_handles_arbitrary_verse);
-   RUN_TEST(test_handles_2_bottles);
-   RUN_TEST(test_handles_1_bottle);
-   RUN_TEST(test_handles_0_bottles);
-   RUN_TEST(test_sings_several_verses);
-   RUN_TEST(test_sings_the_last_4_verses);
+   RUN_TEST(test_first_generic_verse);
+   RUN_TEST(test_last_generic_verse);
+   RUN_TEST(test_verse_with_2_bottles);
+   RUN_TEST(test_verse_with_1_bottle);
+   RUN_TEST(test_verse_with_0_bottles);
+   RUN_TEST(test_first_two_verses);
+   RUN_TEST(test_last_three_verses);
 
    return UnityEnd();
 }


### PR DESCRIPTION
fixes #497 

The test that checks for all verses in one go requires a string that is greater than the length that C allows for strings.
Rather than muck around with memory allocations I've just left it out and set it to false in the TOML, as it seems like it wouldn't add much.

Another thing I haven't updated, is the change from new-line delimited strings to string arrays for the output. Because the scale of the change required vs the impact seemed not worth it. I may look at it again soon though.