### PR TITLE
rail-fence-cipher: align with specification per #519

### DIFF
--- a/exercises/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/rail-fence-cipher/.meta/tests.toml
@@ -13,7 +13,7 @@
 "cd525b17-ec34-45ef-8f0e-4f27c24a7127" = true
 
 # decode with five rails
-#"dd7b4a98-1a52-4e5c-9499-cbb117833507" = true
+"dd7b4a98-1a52-4e5c-9499-cbb117833507" = true
 
 # decode with six rails
-#"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = true
+"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = true

--- a/exercises/rail-fence-cipher/src/example.c
+++ b/exercises/rail-fence-cipher/src/example.c
@@ -2,23 +2,23 @@
 #include <string.h>
 #include <stdlib.h>
 
-char *encode(char *text, size_t rails)
+char *encode(char *msg, size_t rails)
 {
-   size_t length = strlen(text);
+   size_t length = strlen(msg);
    char *ciphertext = (char *)calloc(length + 1, sizeof(char));
    size_t cell_size = 2 * rails - 2;
    if (cell_size == 0) {
-      strcpy(ciphertext, text);
+      strcpy(ciphertext, msg);
       return ciphertext;
    }
    size_t j = 0;
    for (size_t rail = 0; rail < rails; rail++) {
       for (size_t i = 0; i < length; i += cell_size) {
          if (i + rail < length)
-            ciphertext[j++] = text[i + rail];
+            ciphertext[j++] = msg[i + rail];
          if (rail > 0 && rail < rails - 1) {
             if (i + rails + rail < length)
-               ciphertext[j++] = text[i + cell_size - rail];
+               ciphertext[j++] = msg[i + cell_size - rail];
          }
       }
    }

--- a/exercises/rail-fence-cipher/test/test_rail_fence_cipher.c
+++ b/exercises/rail-fence-cipher/test/test_rail_fence_cipher.c
@@ -10,113 +10,67 @@ void tearDown(void)
 {
 }
 
-static void test_expected_value(char *actual, char *expected)
-{
-   TEST_ASSERT_EQUAL_STRING(actual, expected);
-}
-
-static void test_encode_with_empty_string(void)
-{
-   char *res = encode("", 4);
-   test_expected_value("", res);
-   free(res);
-}
-
-static void test_encode_with_one_rail(void)
-{
-   TEST_IGNORE();
-   char *res = encode("One rail, only one rail", 1);
-   test_expected_value("One rail, only one rail", res);
-   free(res);
-}
-
 static void test_encode_with_two_rails(void)
 {
    TEST_IGNORE();
-   char *res = encode("XOXOXOXOXOXOXOXOXO", 2);
-   test_expected_value("XXXXXXXXXOOOOOOOOO", res);
-   free(res);
+   char *actual = encode("XOXOXOXOXOXOXOXOXO", 2);
+   TEST_ASSERT_EQUAL_STRING("XXXXXXXXXOOOOOOOOO", actual);
+   free(actual);
 }
 
 static void test_encode_with_three_rails(void)
 {
    TEST_IGNORE();
-   char *res = encode("WEAREDISCOVEREDFLEEATONCE", 3);
-   test_expected_value("WECRLTEERDSOEEFEAOCAIVDEN", res);
-   free(res);
+   char *actual = encode("WEAREDISCOVEREDFLEEATONCE", 3);
+   TEST_ASSERT_EQUAL_STRING("WECRLTEERDSOEEFEAOCAIVDEN", actual);
+   free(actual);
 }
 
 static void test_encode_with_ending_in_the_middle(void)
 {
    TEST_IGNORE();
-   char *res = encode("EXERCISES", 4);
-   test_expected_value("ESXIEECSR", res);
-   free(res);
-}
-
-static void test_encode_with_less_letters_than_rails(void)
-{
-   TEST_IGNORE();
-   char *res = encode("More rails than letters", 24);
-   test_expected_value("More rails than letters", res);
-   free(res);
-}
-
-static void test_decode_with_empty_string(void)
-{
-   TEST_IGNORE();
-   char *res = decode("", 4);
-   test_expected_value("", res);
-   free(res);
-}
-
-static void test_decode_with_one_rail(void)
-{
-   TEST_IGNORE();
-   char *res = decode("ABCDEFGHIJKLMNOP", 1);
-   test_expected_value("ABCDEFGHIJKLMNOP", res);
-   free(res);
-}
-
-static void test_decode_with_two_rails(void)
-{
-   TEST_IGNORE();
-   char *res = decode("XXXXXXXXXOOOOOOOOO", 2);
-   test_expected_value("XOXOXOXOXOXOXOXOXO", res);
-   free(res);
+   char *actual = encode("EXERCISES", 4);
+   TEST_ASSERT_EQUAL_STRING("ESXIEECSR", actual);
+   free(actual);
 }
 
 static void test_decode_with_three_rails(void)
 {
    TEST_IGNORE();
-   char *res = decode("TEITELHDVLSNHDTISEIIEA", 3);
-   test_expected_value("THEDEVILISINTHEDETAILS", res);
-   free(res);
+   char *actual = decode("TEITELHDVLSNHDTISEIIEA", 3);
+   TEST_ASSERT_EQUAL_STRING("THEDEVILISINTHEDETAILS", actual);
+   free(actual);
 }
 
-static void test_decode_with_four_rails(void)
+static void test_decode_with_five_rails(void)
 {
    TEST_IGNORE();
-   char *res = decode("TSENEHINVRAYREEOONRWERGOH", 4);
-   test_expected_value("THEREISNOGOVERNORANYWHERE", res);
-   free(res);
+   char *actual = decode("EIEXMSMESAORIWSCE", 5);
+   TEST_ASSERT_EQUAL_STRING("EXERCISMISAWESOME", actual);
+   free(actual);
+}
+
+static void test_decode_with_six_rails(void)
+{
+   TEST_IGNORE();
+   char *actual =
+       decode("133714114238148966225439541018335470986172518171757571896261",
+              6);
+   TEST_ASSERT_EQUAL_STRING
+       ("112358132134558914423337761098715972584418167651094617711286", actual);
+   free(actual);
 }
 
 int main(void)
 {
    UnityBegin("test/test_rail_fence_cipher.c");
 
-   RUN_TEST(test_encode_with_empty_string);
-   RUN_TEST(test_encode_with_one_rail);
    RUN_TEST(test_encode_with_two_rails);
    RUN_TEST(test_encode_with_three_rails);
    RUN_TEST(test_encode_with_ending_in_the_middle);
-   RUN_TEST(test_encode_with_less_letters_than_rails);
-   RUN_TEST(test_decode_with_empty_string);
-   RUN_TEST(test_decode_with_one_rail);
-   RUN_TEST(test_decode_with_two_rails);
    RUN_TEST(test_decode_with_three_rails);
-   RUN_TEST(test_decode_with_four_rails);
+   RUN_TEST(test_decode_with_five_rails);
+   RUN_TEST(test_decode_with_six_rails);
 
    return UnityEnd();
 }


### PR DESCRIPTION
- Refactor remove helper function that has only one line
- Match `msg` argument name to spec

fixes #519 