### PR TITLE
roman-numerals: align with specification per #524

### DIFF
--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -22,7 +22,7 @@
 "ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
 
 # 20 is two X's
-#"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = false
 
 # 48 is not 50 - 2 but rather 40 + 8
 "a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
@@ -31,28 +31,28 @@
 "607ead62-23d6-4c11-a396-ef821e2e5f75" = true
 
 # 50 is a single L
-#"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+"d5b283d4-455d-4e68-aacf-add6c4b51915" = false
 
 # 90, being 100 - 10, is XC
-#"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = false
 
 # 100 is a single C
-#"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+"30494be1-9afb-4f84-9d71-db9df18b55e3" = false
 
 # 60, being 50 + 10, is LX
-#"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+"267f0207-3c55-459a-b81d-67cec7a46ed9" = false
 
 # 400, being 500 - 100, is CD
-#"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+"cdb06885-4485-4d71-8bfb-c9d0f496b404" = false
 
 # 500 is a single D
-#"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+"6b71841d-13b2-46b4-ba97-dec28133ea80" = false
 
 # 900, being 1000 - 100, is CM
-#"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+"432de891-7fd6-4748-a7f6-156082eeca2f" = false
 
 # 1000 is a single M
-#"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+"e6de6d24-f668-41c0-88d7-889c0254d173" = false
 
 # 3000 is three M's
 "bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,58 +1,58 @@
 [canonical-tests]
 
-# 1 is a single I
+# 1 is I
 "19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
 
-# 2 is two I's
+# 2 is II
 "f088f064-2d35-4476-9a41-f576da3f7b03" = true
 
-# 3 is three I's
+# 3 is III
 "b374a79c-3bea-43e6-8db8-1286f79c7106" = true
 
-# 4, being 5 - 1, is IV
+# 4 is IV
 "05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
 
-# 5 is a single V
+# 5 is V
 "57c0f9ad-5024-46ab-975d-de18c430b290" = true
 
-# 6, being 5 + 1, is VI
+# 6 is VI
 "20a2b47f-e57f-4797-a541-0b3825d7f249" = true
 
-# 9, being 10 - 1, is IX
+# 9 is IX
 "ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
 
-# 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = false
+# 27 is XXVII
+"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
 
-# 48 is not 50 - 2 but rather 40 + 8
+# 48 is XLVIII
 "a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
 
-# 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
+# 49 is XLIX
 "607ead62-23d6-4c11-a396-ef821e2e5f75" = true
 
-# 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = false
+# 59 is LIX
+"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
 
-# 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = false
+# 93 is XCIII
+"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
 
-# 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = false
+# 141 is CXLI
+"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
 
-# 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = false
+# 163 is CLXIII
+"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
 
-# 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = false
+# 402 is CDII
+"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
 
-# 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = false
+# 575 is DLXXV
+"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
 
-# 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = false
+# 911 is CMXI
+"432de891-7fd6-4748-a7f6-156082eeca2f" = true
 
-# 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = false
+# 1024 is MXXIV
+"e6de6d24-f668-41c0-88d7-889c0254d173" = true
 
-# 3000 is three M's
+# 3000 is MMM
 "bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true

--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -17,115 +17,114 @@ static void check_conversion(int number, char *expected)
    free(result);
 }
 
-static void test_1_is_a_single_I(void)
+static void test_1_is_I(void)
 {
    check_conversion(1, "I");
 }
 
-static void test_2_is_two_Is(void)
+static void test_2_is_II(void)
 {
    TEST_IGNORE();               // delete this line to run test
    check_conversion(2, "II");
 }
 
-static void test_3_is_three_Is(void)
+static void test_3_is_III(void)
 {
    TEST_IGNORE();
    check_conversion(3, "III");
 }
 
-static void test_4_being_5_minus_1_is_IV(void)
+static void test_4_is_IV(void)
 {
    TEST_IGNORE();
    check_conversion(4, "IV");
 }
 
-static void test_5_is_a_single_V(void)
+static void test_5_is_V(void)
 {
    TEST_IGNORE();
    check_conversion(5, "V");
 }
 
-static void test_6_being_5_plus_1_is_VI(void)
+static void test_6_is_VI(void)
 {
    TEST_IGNORE();
    check_conversion(6, "VI");
 }
 
-static void test_nine_being_10_minus_1_is_IX(void)
+static void test_9_is_IX(void)
 {
    TEST_IGNORE();
    check_conversion(9, "IX");
 }
 
-static void test_20_is_two_XXs(void)
+static void test_27_is_XXVII(void)
 {
    TEST_IGNORE();
-   check_conversion(20, "XX");
+   check_conversion(27, "XXVII");
 }
 
-static void test_48_is_not_50_minus_2_but_rather_40_plus_8(void)
+static void test_48_is_XLVIII(void)
 {
    TEST_IGNORE();
    check_conversion(48, "XLVIII");
 }
 
-static void
-test_49_is_not_40_plus_5_plus_4_but_rather_50_minus_10_plus_10_minus_1(void)
+static void test_49_is_XLIX(void)
 {
    TEST_IGNORE();
    check_conversion(49, "XLIX");
 }
 
-static void test_50_is_a_single_L(void)
+static void test_59_is_LIX(void)
 {
    TEST_IGNORE();
-   check_conversion(50, "L");
+   check_conversion(59, "LIX");
 }
 
-static void test_90_being_100_minus_10_is_XC(void)
+static void test_93_is_XCIII(void)
 {
    TEST_IGNORE();
-   check_conversion(90, "XC");
+   check_conversion(93, "XCIII");
 }
 
-static void test_100_is_a_single_C(void)
+static void test_141_is_CXLI(void)
 {
    TEST_IGNORE();
-   check_conversion(100, "C");
+   check_conversion(141, "CXLI");
 }
 
-static void test_sixty_being_50_plus_10_is_LX(void)
+static void test_163_is_CLXIII(void)
 {
    TEST_IGNORE();
-   check_conversion(60, "LX");
+   check_conversion(163, "CLXIII");
 }
 
-static void test_400_being_500_minus_100_is_CD(void)
+static void test_402_is_CDII(void)
 {
    TEST_IGNORE();
-   check_conversion(400, "CD");
+   check_conversion(402, "CDII");
 }
 
-static void test_500_is_a_single_D(void)
+static void test_575_is_DLXXV(void)
 {
    TEST_IGNORE();
-   check_conversion(500, "D");
+   check_conversion(575, "DLXXV");
 }
 
-static void test_900_being_1000_minus_100_is_CM(void)
+static void test_911_is_CMXI(void)
 {
    TEST_IGNORE();
-   check_conversion(900, "CM");
+   check_conversion(911, "CMXI");
 }
 
-static void test_1000_is_a_single_M(void)
+static void test_1024_is_MXXIV(void)
 {
    TEST_IGNORE();
-   check_conversion(1000, "M");
+   check_conversion(1024, "MXXIV");
 }
 
-static void test_3000_is_3_Ms(void)
+static void test_3000_is_MMM(void)
 {
    TEST_IGNORE();
    check_conversion(3000, "MMM");
@@ -135,26 +134,25 @@ int main(void)
 {
    UnityBegin("test_roman_numerals.c");
 
-   RUN_TEST(test_1_is_a_single_I);
-   RUN_TEST(test_2_is_two_Is);
-   RUN_TEST(test_3_is_three_Is);
-   RUN_TEST(test_4_being_5_minus_1_is_IV);
-   RUN_TEST(test_5_is_a_single_V);
-   RUN_TEST(test_6_being_5_plus_1_is_VI);
-   RUN_TEST(test_nine_being_10_minus_1_is_IX);
-   RUN_TEST(test_20_is_two_XXs);
-   RUN_TEST(test_48_is_not_50_minus_2_but_rather_40_plus_8);
-   RUN_TEST
-       (test_49_is_not_40_plus_5_plus_4_but_rather_50_minus_10_plus_10_minus_1);
-   RUN_TEST(test_50_is_a_single_L);
-   RUN_TEST(test_90_being_100_minus_10_is_XC);
-   RUN_TEST(test_100_is_a_single_C);
-   RUN_TEST(test_sixty_being_50_plus_10_is_LX);
-   RUN_TEST(test_400_being_500_minus_100_is_CD);
-   RUN_TEST(test_500_is_a_single_D);
-   RUN_TEST(test_900_being_1000_minus_100_is_CM);
-   RUN_TEST(test_1000_is_a_single_M);
-   RUN_TEST(test_3000_is_3_Ms);
+   RUN_TEST(test_1_is_I);
+   RUN_TEST(test_2_is_II);
+   RUN_TEST(test_3_is_III);
+   RUN_TEST(test_4_is_IV);
+   RUN_TEST(test_5_is_V);
+   RUN_TEST(test_6_is_VI);
+   RUN_TEST(test_9_is_IX);
+   RUN_TEST(test_27_is_XXVII);
+   RUN_TEST(test_48_is_XLVIII);
+   RUN_TEST(test_49_is_XLIX);
+   RUN_TEST(test_59_is_LIX);
+   RUN_TEST(test_93_is_XCIII);
+   RUN_TEST(test_141_is_CXLI);
+   RUN_TEST(test_163_is_CLXIII);
+   RUN_TEST(test_402_is_CDII);
+   RUN_TEST(test_575_is_DLXXV);
+   RUN_TEST(test_911_is_CMXI);
+   RUN_TEST(test_1024_is_MXXIV);
+   RUN_TEST(test_3000_is_MMM);
 
    return UnityEnd();
 }

--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -10,149 +10,151 @@ void tearDown(void)
 {
 }
 
-static void test_conversion(int number, char *expected)
+static void check_conversion(int number, char *expected)
 {
    char *result = to_roman_numeral(number);
    TEST_ASSERT_EQUAL_STRING(expected, result);
    free(result);
 }
 
-static void test_one_yields_I(void)
+static void test_1_is_a_single_I(void)
 {
-   test_conversion(1, "I");
+   check_conversion(1, "I");
 }
 
-static void test_two_yields_II(void)
+static void test_2_is_two_Is(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   test_conversion(2, "II");
+   check_conversion(2, "II");
 }
 
-static void test_three_yields_III(void)
+static void test_3_is_three_Is(void)
 {
    TEST_IGNORE();
-   test_conversion(3, "III");
+   check_conversion(3, "III");
 }
 
-static void test_four_yields_IV(void)
+static void test_4_being_5_minus_1_is_IV(void)
 {
    TEST_IGNORE();
-   test_conversion(4, "IV");
+   check_conversion(4, "IV");
 }
 
-static void test_five_yields_V(void)
+static void test_5_is_a_single_V(void)
 {
    TEST_IGNORE();
-   test_conversion(5, "V");
+   check_conversion(5, "V");
 }
 
-static void test_six_yields_VI(void)
+static void test_6_being_5_plus_1_is_VI(void)
 {
    TEST_IGNORE();
-   test_conversion(6, "VI");
+   check_conversion(6, "VI");
 }
 
-static void test_nine_yields_IX(void)
+static void test_nine_being_10_minus_1_is_IX(void)
 {
    TEST_IGNORE();
-   test_conversion(9, "IX");
+   check_conversion(9, "IX");
 }
 
-static void test_twenty_seven_yields_XXVII(void)
+static void test_20_is_two_XXs(void)
 {
    TEST_IGNORE();
-   test_conversion(27, "XXVII");
+   check_conversion(20, "XX");
 }
 
-static void test_forty_eight_yields_XLVIII(void)
+static void test_48_is_not_50_minus_2_but_rather_40_plus_8(void)
 {
    TEST_IGNORE();
-   test_conversion(48, "XLVIII");
+   check_conversion(48, "XLVIII");
 }
 
-static void test_forty_nine_yields_XLIX(void)
+static void
+test_49_is_not_40_plus_5_plus_4_but_rather_50_minus_10_plus_10_minus_1(void)
 {
    TEST_IGNORE();
-   test_conversion(49, "XLIX");
+   check_conversion(49, "XLIX");
 }
 
-static void test_fifty_nine_yields_LIX(void)
+static void test_50_is_a_single_L(void)
 {
    TEST_IGNORE();
-   test_conversion(59, "LIX");
+   check_conversion(50, "L");
 }
 
-static void test_ninety_three_yields_XCIII(void)
+static void test_90_being_100_minus_10_is_XC(void)
 {
    TEST_IGNORE();
-   test_conversion(93, "XCIII");
+   check_conversion(90, "XC");
 }
 
-static void test_one_hundred_forty_one_yields_CXLI(void)
+static void test_100_is_a_single_C(void)
 {
    TEST_IGNORE();
-   test_conversion(141, "CXLI");
+   check_conversion(100, "C");
 }
 
-static void test_one_hundred_sixty_three_yields_CLXIII(void)
+static void test_sixty_being_50_plus_10_is_LX(void)
 {
    TEST_IGNORE();
-   test_conversion(163, "CLXIII");
+   check_conversion(60, "LX");
 }
 
-static void test_four_hundred_two_yields_CDII(void)
+static void test_400_being_500_minus_100_is_CD(void)
 {
    TEST_IGNORE();
-   test_conversion(402, "CDII");
+   check_conversion(400, "CD");
 }
 
-static void test_five_hundred_seventy_five_yields_DLXXV(void)
+static void test_500_is_a_single_D(void)
 {
    TEST_IGNORE();
-   test_conversion(575, "DLXXV");
+   check_conversion(500, "D");
 }
 
-static void test_nine_hundred_eleven_yields_CMXI(void)
+static void test_900_being_1000_minus_100_is_CM(void)
 {
    TEST_IGNORE();
-   test_conversion(911, "CMXI");
+   check_conversion(900, "CM");
 }
 
-static void test_one_thousand_twenty_four_yields_MXXIV(void)
+static void test_1000_is_a_single_M(void)
 {
    TEST_IGNORE();
-   test_conversion(1024, "MXXIV");
+   check_conversion(1000, "M");
 }
 
-static void test_three_thousand_yields_MMM(void)
+static void test_3000_is_3_Ms(void)
 {
    TEST_IGNORE();
-   test_conversion(3000, "MMM");
+   check_conversion(3000, "MMM");
 }
 
 int main(void)
 {
    UnityBegin("test_roman_numerals.c");
 
-   RUN_TEST(test_one_yields_I);
-   RUN_TEST(test_two_yields_II);
-   RUN_TEST(test_three_yields_III);
-   RUN_TEST(test_four_yields_IV);
-   RUN_TEST(test_five_yields_V);
-   RUN_TEST(test_nine_yields_IX);
-   RUN_TEST(test_six_yields_VI);
-   RUN_TEST(test_twenty_seven_yields_XXVII);
-   RUN_TEST(test_forty_eight_yields_XLVIII);
-   RUN_TEST(test_forty_nine_yields_XLIX);
-   RUN_TEST(test_fifty_nine_yields_LIX);
-   RUN_TEST(test_ninety_three_yields_XCIII);
-   RUN_TEST(test_one_hundred_forty_one_yields_CXLI);
-   RUN_TEST(test_one_hundred_sixty_three_yields_CLXIII);
-   RUN_TEST(test_four_hundred_two_yields_CDII);
-   RUN_TEST(test_five_hundred_seventy_five_yields_DLXXV);
-   RUN_TEST(test_nine_hundred_eleven_yields_CMXI);
-   RUN_TEST(test_one_thousand_twenty_four_yields_MXXIV);
-   RUN_TEST(test_three_thousand_yields_MMM);
+   RUN_TEST(test_1_is_a_single_I);
+   RUN_TEST(test_2_is_two_Is);
+   RUN_TEST(test_3_is_three_Is);
+   RUN_TEST(test_4_being_5_minus_1_is_IV);
+   RUN_TEST(test_5_is_a_single_V);
+   RUN_TEST(test_6_being_5_plus_1_is_VI);
+   RUN_TEST(test_nine_being_10_minus_1_is_IX);
+   RUN_TEST(test_20_is_two_XXs);
+   RUN_TEST(test_48_is_not_50_minus_2_but_rather_40_plus_8);
+   RUN_TEST
+       (test_49_is_not_40_plus_5_plus_4_but_rather_50_minus_10_plus_10_minus_1);
+   RUN_TEST(test_50_is_a_single_L);
+   RUN_TEST(test_90_being_100_minus_10_is_XC);
+   RUN_TEST(test_100_is_a_single_C);
+   RUN_TEST(test_sixty_being_50_plus_10_is_LX);
+   RUN_TEST(test_400_being_500_minus_100_is_CD);
+   RUN_TEST(test_500_is_a_single_D);
+   RUN_TEST(test_900_being_1000_minus_100_is_CM);
+   RUN_TEST(test_1000_is_a_single_M);
+   RUN_TEST(test_3000_is_3_Ms);
 
    return UnityEnd();
 }


### PR DESCRIPTION
Fixes #524 

Impossible to align with specification as it contains logical inconsistencies.
There is an issue raised for this here: https://github.com/exercism/problem-specifications/issues/1769
This PR should remain in draft status until the above issue is resolved.