### PR TITLE
wordy: align with specification per #530

### DIFF
--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -1,7 +1,7 @@
 [canonical-tests]
 
 # just a number
-#"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
+"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
 
 # addition
 "bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
@@ -52,19 +52,19 @@
 "8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
 
 # reject problem missing an operand
-#"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
+"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
 
 # reject problem with no operands or operators
-#"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
+"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
 
 # reject two operations in a row
-#"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
+"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
 
 # reject two numbers in a row
-#"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
+"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
 
 # reject postfix notation
-#"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
+"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
 
 # reject prefix notation
-#"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true
+"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true

--- a/exercises/wordy/test/test_wordy.c
+++ b/exercises/wordy/test/test_wordy.c
@@ -9,8 +9,19 @@ void tearDown(void)
 {
 }
 
-static void test_answer_addition(void)
+static void test_just_a_number(void)
 {
+   const char *question = "What is 5?";
+   const int expected = 5;
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_TRUE(success);
+   TEST_ASSERT_EQUAL_INT(expected, result);
+}
+
+static void test_addition(void)
+{
+   TEST_IGNORE();               // delete this line to run test
    const char *question = "What is 1 plus 1?";
    const int expected = 2;
    int result;
@@ -19,9 +30,9 @@ static void test_answer_addition(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_more_addition(void)
+static void test_more_addition(void)
 {
-   TEST_IGNORE();               // delete this line to run test
+   TEST_IGNORE();
    const char *question = "What is 53 plus 2?";
    const int expected = 55;
    int result;
@@ -30,7 +41,7 @@ static void test_answer_more_addition(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_addition_with_negative_numbers(void)
+static void test_addition_with_negative_numbers(void)
 {
    TEST_IGNORE();
    const char *question = "What is -1 plus -10?";
@@ -41,7 +52,7 @@ static void test_answer_addition_with_negative_numbers(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_large_addition(void)
+static void test_large_addition(void)
 {
    TEST_IGNORE();
    const char *question = "What is 123 plus 45678?";
@@ -52,7 +63,7 @@ static void test_answer_large_addition(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_subtraction(void)
+static void test_subtraction(void)
 {
    TEST_IGNORE();
    const char *question = "What is 4 minus -12?";
@@ -63,7 +74,7 @@ static void test_answer_subtraction(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_multiplication(void)
+static void test_multiplication(void)
 {
    TEST_IGNORE();
    const char *question = "What is -3 multiplied by 25?";
@@ -74,7 +85,7 @@ static void test_answer_multiplication(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_division(void)
+static void test_division(void)
 {
    TEST_IGNORE();
    const char *question = "What is 33 divided by -3?";
@@ -85,7 +96,7 @@ static void test_answer_division(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_multiple_additions(void)
+static void test_multiple_additions(void)
 {
    TEST_IGNORE();
    const char *question = "What is 1 plus 1 plus 1?";
@@ -96,7 +107,7 @@ static void test_answer_multiple_additions(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_addition_and_subtraction(void)
+static void test_addition_and_subtraction(void)
 {
    TEST_IGNORE();
    const char *question = "What is 1 plus 5 minus -2?";
@@ -107,7 +118,7 @@ static void test_answer_addition_and_subtraction(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_multiple_subtraction(void)
+static void test_multiple_subtraction(void)
 {
    TEST_IGNORE();
    const char *question = "What is 20 minus 4 minus 13?";
@@ -118,7 +129,7 @@ static void test_answer_multiple_subtraction(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_subtraction_then_addition(void)
+static void test_subtraction_then_addition(void)
 {
    TEST_IGNORE();
    const char *question = "What is 17 minus 6 plus 3?";
@@ -129,7 +140,7 @@ static void test_answer_subtraction_then_addition(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_multiple_multiplication(void)
+static void test_multiple_multiplication(void)
 {
    TEST_IGNORE();
    const char *question = "What is 2 multiplied by -2 multiplied by 3?";
@@ -140,7 +151,7 @@ static void test_answer_multiple_multiplication(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_addition_and_multiplication(void)
+static void test_addition_and_multiplication(void)
 {
    TEST_IGNORE();
    const char *question = "What is -3 plus 7 multiplied by -2?";
@@ -151,7 +162,7 @@ static void test_answer_addition_and_multiplication(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_multiple_division(void)
+static void test_multiple_division(void)
 {
    TEST_IGNORE();
    const char *question = "What is -12 divided by 2 divided by -3?";
@@ -162,7 +173,7 @@ static void test_answer_multiple_division(void)
    TEST_ASSERT_EQUAL_INT(expected, result);
 }
 
-static void test_answer_unknown_operation(void)
+static void test_unknown_operation(void)
 {
    TEST_IGNORE();
    const char *question = "What is 52 cubed?";
@@ -171,10 +182,64 @@ static void test_answer_unknown_operation(void)
    TEST_ASSERT_FALSE(success);
 }
 
-static void test_answer_non_math_question(void)
+static void test_non_math_question(void)
 {
    TEST_IGNORE();
    const char *question = "Who is the President of the United States?";
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_FALSE(success);
+}
+
+static void test_reject_a_problem_missing_an_operand(void)
+{
+   TEST_IGNORE();
+   const char *question = "What is 1 plus?";
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_FALSE(success);
+}
+
+static void test_reject_problem_with_no_operands_or_operators(void)
+{
+   TEST_IGNORE();
+   const char *question = "What is?";
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_FALSE(success);
+}
+
+static void test_reject_two_operations_in_a_row(void)
+{
+   TEST_IGNORE();
+   const char *question = "What is 1 plus plus 2?";
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_FALSE(success);
+}
+
+static void test_reject_two_numbers_in_a_row(void)
+{
+   TEST_IGNORE();
+   const char *question = "What is 1 plus plus 2 1?";
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_FALSE(success);
+}
+
+static void test_reject_postix_notation(void)
+{
+   TEST_IGNORE();
+   const char *question = "What is 1 2 plus?";
+   int result;
+   bool success = answer(question, &result);
+   TEST_ASSERT_FALSE(success);
+}
+
+static void test_reject_prefix_notation(void)
+{
+   TEST_IGNORE();
+   const char *question = "What is plus 1 2?";
    int result;
    bool success = answer(question, &result);
    TEST_ASSERT_FALSE(success);
@@ -184,22 +249,29 @@ int main(void)
 {
    UnityBegin("test/test_wordy.c");
 
-   RUN_TEST(test_answer_addition);
-   RUN_TEST(test_answer_more_addition);
-   RUN_TEST(test_answer_addition_with_negative_numbers);
-   RUN_TEST(test_answer_large_addition);
-   RUN_TEST(test_answer_subtraction);
-   RUN_TEST(test_answer_multiplication);
-   RUN_TEST(test_answer_division);
-   RUN_TEST(test_answer_multiple_additions);
-   RUN_TEST(test_answer_addition_and_subtraction);
-   RUN_TEST(test_answer_multiple_subtraction);
-   RUN_TEST(test_answer_subtraction_then_addition);
-   RUN_TEST(test_answer_multiple_multiplication);
-   RUN_TEST(test_answer_addition_and_multiplication);
-   RUN_TEST(test_answer_multiple_division);
-   RUN_TEST(test_answer_unknown_operation);
-   RUN_TEST(test_answer_non_math_question);
+   RUN_TEST(test_just_a_number);
+   RUN_TEST(test_addition);
+   RUN_TEST(test_more_addition);
+   RUN_TEST(test_addition_with_negative_numbers);
+   RUN_TEST(test_large_addition);
+   RUN_TEST(test_subtraction);
+   RUN_TEST(test_multiplication);
+   RUN_TEST(test_division);
+   RUN_TEST(test_multiple_additions);
+   RUN_TEST(test_addition_and_subtraction);
+   RUN_TEST(test_multiple_subtraction);
+   RUN_TEST(test_subtraction_then_addition);
+   RUN_TEST(test_multiple_multiplication);
+   RUN_TEST(test_addition_and_multiplication);
+   RUN_TEST(test_multiple_division);
+   RUN_TEST(test_unknown_operation);
+   RUN_TEST(test_non_math_question);
+   RUN_TEST(test_reject_a_problem_missing_an_operand);
+   RUN_TEST(test_reject_problem_with_no_operands_or_operators);
+   RUN_TEST(test_reject_two_operations_in_a_row);
+   RUN_TEST(test_reject_two_numbers_in_a_row);
+   RUN_TEST(test_reject_postix_notation);
+   RUN_TEST(test_reject_prefix_notation);
 
    return UnityEnd();
 }

--- a/exercises/wordy/test/test_wordy.c
+++ b/exercises/wordy/test/test_wordy.c
@@ -227,7 +227,7 @@ static void test_reject_two_numbers_in_a_row(void)
    TEST_ASSERT_FALSE(success);
 }
 
-static void test_reject_postix_notation(void)
+static void test_reject_postfix_notation(void)
 {
    TEST_IGNORE();
    const char *question = "What is 1 2 plus?";
@@ -270,7 +270,7 @@ int main(void)
    RUN_TEST(test_reject_problem_with_no_operands_or_operators);
    RUN_TEST(test_reject_two_operations_in_a_row);
    RUN_TEST(test_reject_two_numbers_in_a_row);
-   RUN_TEST(test_reject_postix_notation);
+   RUN_TEST(test_reject_postfix_notation);
    RUN_TEST(test_reject_prefix_notation);
 
    return UnityEnd();


### PR DESCRIPTION
Fixes #530 

Interesting to see the x-macros in the `example.c`. I think it's the only "real-world"  use of them that I have seen, that does not involve enumerations, for a very long time!