### PR TITLE
Remove v2 configlet use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
 
     - name: checks
       run: |
-        ./bin/fetch-configlet
-        ./bin/configlet lint .
         ./bin/verify-indent
         ./bin/check-unitybegin
         ./bin/verify-unity-version


### PR DESCRIPTION
CI is currently failing. 
This is because the track has moved to v3, but the v2 configlet is run by files not overwritten by the v3 files.
this change removes the v2 configlet run from the `build.yml` leaving only the new v3 configlet run in `configlet.yml`.
