### PR TITLE
Fix check-unitybegin, check-unity-version, run-tests

### DIFF
--- a/bin/check-unitybegin
+++ b/bin/check-unitybegin
@@ -9,7 +9,7 @@ set +e
 
 ERROR_COUNT=0
 
-for f in exercises/*/test/test_*; do
+for f in exercises/practice/*/test/test_*; do
     if ! grep -q UnityBegin\(\"test/"$(basename "$f")"\"\) "$f"; then
         echo "$f needs correct UnityBegin line"
         (( ERROR_COUNT++ ))

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -42,11 +42,11 @@ execute_test () {
 # Clone the exercises directory to avoid pollution
 if [ $# -gt 0 ]; then
     mkdir build
-    cd exercises
-    cp -r "$@" ../build
-    cd ../build/
+    cd exercises/practice
+    cp -r "$@" ../../build
+    cd ../../build/
 else
-    cp -r exercises build
+    cp -r exercises/practice build
     cd build/
 fi
 
@@ -60,4 +60,3 @@ else
         execute_test "$exercise"
     done
 fi
-

--- a/bin/verify-unity-version
+++ b/bin/verify-unity-version
@@ -27,7 +27,7 @@ test_unity_version() {
 }
 
 ERROR_COUNT=0
-for f in exercises/*/test/vendor/unity.h; do
+for f in exercises/practice/*/test/vendor/unity.h; do
     if ! test_unity_version "$f"; then
         echo "$f unexpected unity version"
         (( ERROR_COUNT++ ))


### PR DESCRIPTION
The root cause was that exercises moved from `exercises/*` to `exercises/practice/*` which broke scripts that searched in `exercises/*`