### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 C is a general purpose language, used for a wide range of applications, from embedded computers to high-performance computing clusters. 
 
 C is commonly found in low level applications as it's a good alternative to harder-to-read assembly languages. It can be compiled to assembly to keep the same level of performance, while increasing readability, and providing a small level of safety with static types!

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 The C language track requires that you have the following software installed
 on your system:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -12,7 +12,7 @@ environment). Linux environments typically expose the compiler and native
 build system as separate command-line tools.
 
 
-#### Linux
+## Linux
 
 Linux users will need gcc or clang for the compiler, and `make` will be needed
 for the native build. Make is pre-installed on most unix systems, but is most
@@ -21,13 +21,13 @@ distributions everything you need can be installed with `sudo apt-get install bu
 if not present.
 
 
-#### MacOS
+## MacOS
 
 MacOS users can install gcc or clang with [Homebrew](http://brew.sh/) via
 `brew install gcc` or `brew install llvm`.
 
 
-#### Windows
+## Windows
 
 Windows 10 users are recommended to use [WSL Bash](https://msdn.microsoft.com/en-us/commandline/wsl/about), and proceed with the instruction for linux above.
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Learning C From Ground Zero
 
 In general, exercism assumes you already know the syntax and mechanisms

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,2 +1,4 @@
+# Resources
+
 - [C++ Reference](http://en.cppreference.com/w/): An online reference for C and C++ programming languages. You have a doubt what a method does? cppreference.com has you covered.
 - [`C` tag on StackOverflow](http://stackoverflow.com/questions/tagged/c)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Each exercise supplies the unit tests and a Make build recipe.
 You provide the implementation.
 

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -1,1 +1,3 @@
+# Versions
+
 - Unity = v2.5.0 (version now specified in `unity.h`)

--- a/exercises/practice/square-root/.meta/description.md
+++ b/exercises/practice/square-root/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Given a natural radicand, return its square root.
 
 Check out the Wikipedia pages on [square root](https://en.wikipedia.org/wiki/Square_root) and [methods of computing square roots](https://en.wikipedia.org/wiki/Methods_of_computing_square_roots).

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -1,1 +1,3 @@
+# Instructions append
+
 - Note that the tests for this exercise expect the output words to be proper C strings. That is, they should be NUL terminated. See https://en.wikipedia.org/wiki/C_string_handling


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
