### PR TITLE
Rescue the list of concepts from the old v3 repo

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -1,0 +1,105 @@
+# C Reference
+
+## Concepts
+
+The C concept exercises are based on language concepts. The list below contains the concepts that have been identified for the C language. The list is initially based on the [v3 reference concepts][v3-reference-concepts], and using the references at the bottom of this page.
+
+### Specialities
+
+#### Concepts
+
+- [Algorithms](https://en.cppreference.com/w/c/algorithm)
+- [Bit Fields](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Bit-Fields)
+- [Blocks](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Blocks)
+- [Calling Functions Through Function Pointers](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Calling-Functions-Through-Function-Pointers)
+- [Date and Time Utilities](https://en.cppreference.com/w/c/chrono)
+- [Definition of `main()`](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#The-main-Function)
+- [Dynamic Memory Management](https://en.cppreference.com/w/c/memory)
+- [File Input/Output](https://en.cppreference.com/w/c/io)
+- [Goto Statement](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#The-goto-Statement)
+- [Includes](https://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html)
+- [Incomplete Types](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Incomplete-Types)
+- [Labels](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Labels)
+- [Macros](https://gcc.gnu.org/onlinedocs/cpp/Macros.html#Macros)
+- [Null Statement](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#The-Null-Statement)
+- [Program Structure](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Program-Structure)
+- [Preprocessor Directives](https://en.wikipedia.org/wiki/C_preprocessor#Special_macros_and_directives)
+- [Renaming Types](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Renaming-Types)
+- [Scope](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Scope)
+- [Static Functions](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Static-Functions)
+- [Storage Class Specifiers](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Storage-Class-Specifiers)
+- [Switch Statement](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#The-switch-Statement)
+- [Strings library](https://en.cppreference.com/w/c/string)
+- [Undefined behaviour](https://en.wikipedia.org/wiki/Undefined_behavior)
+- [Variable Length Parameter Lists](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Variable-Length-Parameter-Lists)
+- [Volatile](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Type-Qualifiers)
+
+#### Types
+
+- [Complex Number Types](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Complex-Number-Types)
+- [Enumerations](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Enumerations)
+- [Fixed width integer types](https://en.wikipedia.org/wiki/C_data_types#Fixed-width_integer_types)
+- [ptrdiff_t](https://www.gnu.org/software/libc/manual/html_node/Important-Data-Types.html)
+- [size_t](https://www.gnu.org/software/libc/manual/html_node/Important-Data-Types.html)
+- [Unions](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Unions)
+- [Void](https://en.wikipedia.org/wiki/Void_type)
+
+#### Patterns
+
+- [Callback](<https://en.wikipedia.org/wiki/Callback_(computer_programming)>)
+- [Opaque pointers](https://en.wikipedia.org/wiki/Opaque_pointer)
+
+### General
+
+#### Concepts
+
+- [Arithmetic](https://github.com/exercism/v3/blob/master/reference/concepts/arithmetic.md)
+- [ASCII](https://github.com/exercism/v3/blob/master/reference/concepts/ascii.md)
+- [Assignment](https://github.com/exercism/v3/blob/master/reference/concepts/assignment.md)
+- [Bitwise manipulation](https://github.com/exercism/v3/blob/master/reference/concepts/bitwise_manipulation.md)
+- [Boolean logic](https://github.com/exercism/v3/blob/master/reference/concepts/boolean_logic.md)
+- [Comments](https://github.com/exercism/v3/blob/master/reference/concepts/comments.md)
+- [Comparisons](https://github.com/exercism/v3/blob/master/reference/concepts/comparisons.md)
+- [Conditionals](https://github.com/exercism/v3/blob/master/reference/concepts/conditionals.md)
+- [Constants](https://github.com/exercism/v3/blob/master/reference/concepts/constants.md)
+- [Expressions](https://github.com/exercism/v3/blob/master/reference/concepts/expressions.md)
+- [Functions](https://github.com/exercism/v3/blob/master/reference/concepts/functions.md)
+- [Loops](https://github.com/exercism/v3/blob/master/reference/concepts/loops.md)
+- [Macros](https://github.com/exercism/v3/blob/master/reference/concepts/macros.md)
+- [Operators](https://github.com/exercism/v3/blob/master/reference/concepts/operators.md)
+- [Recursion](https://github.com/exercism/v3/blob/master/reference/concepts/recursion.md)
+- [Return value(s)](https://github.com/exercism/v3/blob/master/reference/concepts/return_values.md)
+- [Scope](https://github.com/exercism/v3/blob/master/reference/concepts/scope.md)
+- [Signedness](https://github.com/exercism/v3/blob/master/reference/concepts/signedness.md)
+- [Type casting (type conversion, type coercion)](https://github.com/exercism/v3/blob/master/reference/concepts/type_casting.md)
+- [Variable Shadowing](https://github.com/exercism/v3/blob/master/reference/concepts/variable_shadowing.md)
+- [Variables](https://github.com/exercism/v3/blob/master/reference/concepts/variables.md)
+
+#### Types
+
+- [Array](https://github.com/exercism/v3/blob/master/reference/types/array.md)
+- [Bit](https://github.com/exercism/v3/blob/master/reference/types/bit.md)
+- [Boolean](https://github.com/exercism/v3/blob/master/reference/types/boolean.md)
+- [Byte](https://github.com/exercism/v3/blob/master/reference/types/byte.md)
+- [Bytes](https://github.com/exercism/v3/blob/master/reference/types/bytes.md)
+- [Char](https://github.com/exercism/v3/blob/master/reference/types/char.md)
+- [Double](https://github.com/exercism/v3/blob/master/reference/types/double.md)
+- [Floating-point number](https://github.com/exercism/v3/blob/master/reference/types/floating_point_number.md)
+- [Integer](https://github.com/exercism/v3/blob/master/reference/types/integer.md)
+- [Long](https://github.com/exercism/v3/blob/master/reference/types/long.md)
+- [Null](https://github.com/exercism/v3/blob/master/reference/types/null.md)
+- [Pointer](https://github.com/exercism/v3/blob/master/reference/types/pointer.md)
+- [Short](https://github.com/exercism/v3/blob/master/reference/types/short.md)
+- [Signed number representation](https://github.com/exercism/v3/blob/master/reference/types/signed.md)
+- [String](https://github.com/exercism/v3/blob/master/reference/types/string.md)
+- [Struct](https://github.com/exercism/v3/blob/master/reference/types/struct.md)
+- [Unsigned number representation](https://github.com/exercism/v3/blob/master/reference/types/unsigned.md)
+
+## Resources used
+
+- [cppreference](https://en.cppreference.com/w/)
+- [The GNU C Preprocessor Manual](https://gcc.gnu.org/onlinedocs/cpp/index.html)
+- [The GNU C Reference Manual](https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html)
+- [Wikipedia](https://en.wikipedia.org)
+
+[v3-reference-concepts]: https://github.com/exercism/v3/tree/master/reference


### PR DESCRIPTION
It was here: https://github.com/exercism/v3/tree/main/languages/c/reference

I think this should not stay here, with the new structure coming; but it is useful to have to work with for some time until v3 launches.