### PR TITLE
Linked list

### DIFF
--- a/exercises/practice/linked-list/.meta/example.c
+++ b/exercises/practice/linked-list/.meta/example.c
@@ -107,6 +107,32 @@ ll_data_t list_shift(struct list * list)
    return result;
 }
 
+void list_delete(struct list *list, ll_data_t data)
+{
+   assert(list);
+
+   struct list_node *node = list->first;
+
+   while(node) {
+      if (node->data == data)
+      {
+         if (node == list->first)
+            list->first = node->next;
+         else
+            node->prev->next = node->next;
+
+         if (node == list->last)
+            list->last = node->prev;
+         else
+            node->next->prev = node->prev;
+
+         free(node);
+         return;
+      }
+      node = node->next;
+   }
+}
+
 void list_destroy(struct list *list)
 {
    if (!list)

--- a/exercises/practice/linked-list/.meta/example.c
+++ b/exercises/practice/linked-list/.meta/example.c
@@ -6,6 +6,7 @@ struct list_node {
    struct list_node *prev, *next;
    ll_data_t data;
 };
+
 struct list {
    struct list_node *first, *last;
 };
@@ -33,10 +34,19 @@ struct list *list_create(void)
    return list;
 }
 
-bool list_is_empty(const struct list * list)
+size_t list_count(const struct list *list)
 {
    assert(list);
-   return list->first == NULL;
+
+   size_t count = 0;
+   struct list_node *node = list->first;
+
+   while (node) {
+      ++count;
+      node = node->next;
+   }
+
+   return count;
 }
 
 bool list_push(struct list * list, ll_data_t data)

--- a/exercises/practice/linked-list/.meta/example.c
+++ b/exercises/practice/linked-list/.meta/example.c
@@ -49,7 +49,7 @@ size_t list_count(const struct list *list)
    return count;
 }
 
-bool list_push(struct list * list, ll_data_t data)
+struct list_node *list_push(struct list * list, ll_data_t data)
 {
    assert(list);
    struct list_node *node = list_node_create(list->last, NULL, data);
@@ -78,7 +78,7 @@ ll_data_t list_pop(struct list * list)
    return result;
 }
 
-bool list_unshift(struct list * list, ll_data_t data)
+struct list_node *list_unshift(struct list * list, ll_data_t data)
 {
    assert(list);
    struct list_node *node = list_node_create(NULL, list->first, data);

--- a/exercises/practice/linked-list/.meta/example.c
+++ b/exercises/practice/linked-list/.meta/example.c
@@ -49,18 +49,18 @@ size_t list_count(const struct list * list)
    return count;
 }
 
-struct list_node *list_push(struct list *list, ll_data_t data)
+void list_push(struct list *list, ll_data_t data)
 {
    assert(list);
    struct list_node *node = list_node_create(list->last, NULL, data);
    if (!node)
-      return NULL;
+      return;
    list->last = node;
    if (!list->first)
       list->first = node;
    else
       node->prev->next = node;
-   return node;
+   return;
 }
 
 ll_data_t list_pop(struct list * list)
@@ -78,18 +78,18 @@ ll_data_t list_pop(struct list * list)
    return result;
 }
 
-struct list_node *list_unshift(struct list *list, ll_data_t data)
+void list_unshift(struct list *list, ll_data_t data)
 {
    assert(list);
    struct list_node *node = list_node_create(NULL, list->first, data);
    if (!node)
-      return NULL;
+      return;
    list->first = node;
    if (!list->last)
       list->last = node;
    else
       node->next->prev = node;
-   return node;
+   return;
 }
 
 ll_data_t list_shift(struct list * list)

--- a/exercises/practice/linked-list/.meta/example.c
+++ b/exercises/practice/linked-list/.meta/example.c
@@ -34,7 +34,7 @@ struct list *list_create(void)
    return list;
 }
 
-size_t list_count(const struct list *list)
+size_t list_count(const struct list * list)
 {
    assert(list);
 
@@ -49,7 +49,7 @@ size_t list_count(const struct list *list)
    return count;
 }
 
-struct list_node *list_push(struct list * list, ll_data_t data)
+struct list_node *list_push(struct list *list, ll_data_t data)
 {
    assert(list);
    struct list_node *node = list_node_create(list->last, NULL, data);
@@ -78,7 +78,7 @@ ll_data_t list_pop(struct list * list)
    return result;
 }
 
-struct list_node *list_unshift(struct list * list, ll_data_t data)
+struct list_node *list_unshift(struct list *list, ll_data_t data)
 {
    assert(list);
    struct list_node *node = list_node_create(NULL, list->first, data);
@@ -113,9 +113,8 @@ void list_delete(struct list *list, ll_data_t data)
 
    struct list_node *node = list->first;
 
-   while(node) {
-      if (node->data == data)
-      {
+   while (node) {
+      if (node->data == data) {
          if (node == list->first)
             list->first = node->next;
          else

--- a/exercises/practice/linked-list/.meta/example.h
+++ b/exercises/practice/linked-list/.meta/example.h
@@ -2,6 +2,7 @@
 #define LINKED_LIST_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef int ll_data_t;
 struct list;
@@ -9,22 +10,22 @@ struct list;
 // constructs a new (empty) list
 struct list *list_create(void);
 
-// checks if the list is empty
-bool list_is_empty(const struct list *list);
+// counts the items on a list
+size_t list_count(const struct list *list);
 
-// inserts item at back of list
+// inserts item at back of a list
 bool list_push(struct list *list, ll_data_t item_data);
 
-// removes item from back of list
+// removes item from back of a list
 ll_data_t list_pop(struct list *list);
 
-// inserts item at front of list
+// inserts item at front of a list
 bool list_unshift(struct list *list, ll_data_t item_data);
 
-// removes item from front of list
+// removes item from front of a list
 ll_data_t list_shift(struct list *list);
 
-// destroys the entire list
+// destroys an entire list
 // list will be a dangling pointer after calling this method on it
 void list_destroy(struct list *list);
 

--- a/exercises/practice/linked-list/.meta/example.h
+++ b/exercises/practice/linked-list/.meta/example.h
@@ -13,13 +13,13 @@ struct list *list_create(void);
 size_t list_count(const struct list *list);
 
 // inserts item at back of a list
-struct list_node *list_push(struct list *list, ll_data_t item_data);
+void list_push(struct list *list, ll_data_t item_data);
 
 // removes item from back of a list
 ll_data_t list_pop(struct list *list);
 
 // inserts item at front of a list
-struct list_node *list_unshift(struct list *list, ll_data_t item_data);
+void list_unshift(struct list *list, ll_data_t item_data);
 
 // removes item from front of a list
 ll_data_t list_shift(struct list *list);

--- a/exercises/practice/linked-list/.meta/example.h
+++ b/exercises/practice/linked-list/.meta/example.h
@@ -1,7 +1,6 @@
 #ifndef LINKED_LIST_H
 #define LINKED_LIST_H
 
-#include <stdbool.h>
 #include <stddef.h>
 
 typedef int ll_data_t;
@@ -14,13 +13,13 @@ struct list *list_create(void);
 size_t list_count(const struct list *list);
 
 // inserts item at back of a list
-bool list_push(struct list *list, ll_data_t item_data);
+struct list_node *list_push(struct list *list, ll_data_t item_data);
 
 // removes item from back of a list
 ll_data_t list_pop(struct list *list);
 
 // inserts item at front of a list
-bool list_unshift(struct list *list, ll_data_t item_data);
+struct list_node *list_unshift(struct list *list, ll_data_t item_data);
 
 // removes item from front of a list
 ll_data_t list_shift(struct list *list);

--- a/exercises/practice/linked-list/.meta/example.h
+++ b/exercises/practice/linked-list/.meta/example.h
@@ -24,6 +24,9 @@ struct list_node *list_unshift(struct list *list, ll_data_t item_data);
 // removes item from front of a list
 ll_data_t list_shift(struct list *list);
 
+// deletes a node that holds the matching data
+void list_delete(struct list *list, ll_data_t data);
+
 // destroys an entire list
 // list will be a dangling pointer after calling this method on it
 void list_destroy(struct list *list);

--- a/exercises/practice/linked-list/.meta/tests.toml
+++ b/exercises/practice/linked-list/.meta/tests.toml
@@ -1,0 +1,58 @@
+[canonical-tests]
+
+# pop gets element from the list
+"7f7e3987-b954-41b8-8084-99beca08752c" = true
+
+# push/pop respectively add/remove at the end of the list
+"c3f67e5d-cfa2-4c3e-a18f-7ce999c3c885" = true
+
+# shift gets an element from the list
+"00ea24ce-4f5c-4432-abb4-cc6e85462657" = true
+
+# shift gets first element from the list
+"37962ee0-3324-4a29-b588-5a4c861e6564" = true
+
+# unshift adds element at start of the list
+"30a3586b-e9dc-43fb-9a73-2770cec2c718" = true
+
+# pop, push, shift, and unshift can be used in any order
+"042f71e4-a8a7-4cf0-8953-7e4f3a21c42d" = true
+
+# count an empty list
+"88f65c0c-4532-4093-8295-2384fb2f37df" = true
+
+# count a list with items
+"fc055689-5cbe-4cd9-b994-02e2abbb40a5" = true
+
+# count is correct after mutation
+"8272cef5-130d-40ea-b7f6-5ffd0790d650" = true
+
+# popping to empty doesn't break the list
+"229b8f7a-bd8a-4798-b64f-0dc0bb356d95" = true
+
+# shifting to empty doesn't break the list
+"4e1948b4-514e-424b-a3cf-a1ebbfa2d1ad" = true
+
+# deletes the only element
+"e8f7c600-d597-4f79-949d-8ad8bae895a6" = true
+
+# deletes the element with the specified value from the list
+"fd65e422-51f3-45c0-9fd0-c33da638f89b" = true
+
+# deletes the element with the specified value from the list, re-assigns tail
+"59db191a-b17f-4ab7-9c5c-60711ec1d013" = true
+
+# deletes the element with the specified value from the list, re-assigns head
+"58242222-5d39-415b-951d-8128247f8993" = true
+
+# deletes the first of two elements
+"ee3729ee-3405-4bd2-9bad-de0d4aa5d647" = true
+
+# deletes the second of two elements
+"47e3b3b4-b82c-4c23-8c1a-ceb9b17cb9fb" = true
+
+# delete does not modify the list if the element is not found
+"7b420958-f285-4922-b8f9-10d9dcab5179" = true
+
+# deletes only the first occurrence
+"7e04828f-6082-44e3-a059-201c63252a76" = true

--- a/exercises/practice/linked-list/linked_list.c
+++ b/exercises/practice/linked-list/linked_list.c
@@ -4,6 +4,7 @@ struct list_node {
    struct list_node *prev, *next;
    ll_data_t data;
 };
+
 struct list {
    struct list_node *first, *last;
 };

--- a/exercises/practice/linked-list/linked_list.h
+++ b/exercises/practice/linked-list/linked_list.h
@@ -13,13 +13,13 @@ struct list *list_create(void);
 size_t list_count(const struct list *list);
 
 // inserts item at back of a list
-struct list_node *list_push(struct list *list, ll_data_t item_data);
+void list_push(struct list *list, ll_data_t item_data);
 
 // removes item from back of a list
 ll_data_t list_pop(struct list *list);
 
 // inserts item at front of a list
-struct list_node *list_unshift(struct list *list, ll_data_t item_data);
+void list_unshift(struct list *list, ll_data_t item_data);
 
 // removes item from front of a list
 ll_data_t list_shift(struct list *list);

--- a/exercises/practice/linked-list/linked_list.h
+++ b/exercises/practice/linked-list/linked_list.h
@@ -9,22 +9,22 @@ struct list;
 // constructs a new (empty) list
 struct list *list_create(void);
 
-// checks if the list is empty
-bool list_is_empty(const struct list *list);
+// counts the items on a list
+bool list_count(const struct list *list);
 
-// inserts item at back of list
+// inserts item at back of a list
 bool list_push(struct list *list, ll_data_t item_data);
 
-// removes item from back of list
+// removes item from back of a list
 ll_data_t list_pop(struct list *list);
 
-// inserts item at front of list
+// inserts item at front of a list
 bool list_unshift(struct list *list, ll_data_t item_data);
 
-// removes item from front of list
+// removes item from front of a list
 ll_data_t list_shift(struct list *list);
 
-// destroys the entire list
+// destroys an entire list
 // list will be a dangling pointer after calling this method on it
 void list_destroy(struct list *list);
 

--- a/exercises/practice/linked-list/linked_list.h
+++ b/exercises/practice/linked-list/linked_list.h
@@ -24,6 +24,9 @@ struct list_node *list_unshift(struct list *list, ll_data_t item_data);
 // removes item from front of a list
 ll_data_t list_shift(struct list *list);
 
+// deletes a node that holds the matching data
+void list_delete(struct list *list, ll_data_t data);
+
 // destroys an entire list
 // list will be a dangling pointer after calling this method on it
 void list_destroy(struct list *list);

--- a/exercises/practice/linked-list/linked_list.h
+++ b/exercises/practice/linked-list/linked_list.h
@@ -1,7 +1,7 @@
 #ifndef LINKED_LIST_H
 #define LINKED_LIST_H
 
-#include <stdbool.h>
+#include <stddef.h>
 
 typedef int ll_data_t;
 struct list;
@@ -10,16 +10,16 @@ struct list;
 struct list *list_create(void);
 
 // counts the items on a list
-bool list_count(const struct list *list);
+size_t list_count(const struct list *list);
 
 // inserts item at back of a list
-bool list_push(struct list *list, ll_data_t item_data);
+struct list_node *list_push(struct list *list, ll_data_t item_data);
 
 // removes item from back of a list
 ll_data_t list_pop(struct list *list);
 
 // inserts item at front of a list
-bool list_unshift(struct list *list, ll_data_t item_data);
+struct list_node *list_unshift(struct list *list, ll_data_t item_data);
 
 // removes item from front of a list
 ll_data_t list_shift(struct list *list);

--- a/exercises/practice/linked-list/test_linked_list.c
+++ b/exercises/practice/linked-list/test_linked_list.c
@@ -145,9 +145,8 @@ test_deletes_the_element_with_the_specified_value_from_the_list(void)
 }
 
 static void
-test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail
-(void)
-{
+ test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail
+    (void) {
    TEST_IGNORE();
    list_push(list, 71);
    list_push(list, 83);
@@ -159,9 +158,8 @@ test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail
 }
 
 static void
-test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head
-(void)
-{
+ test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head
+    (void) {
    TEST_IGNORE();
    list_push(list, 71);
    list_push(list, 83);

--- a/exercises/practice/linked-list/test_linked_list.c
+++ b/exercises/practice/linked-list/test_linked_list.c
@@ -17,109 +17,221 @@ void tearDown(void)
    }
 }
 
-static void test_list_create(void)
+static void test_pop_gets_element_from_the_list(void)
+{
+   list_push(list, 7);
+   TEST_ASSERT_EQUAL(7, list_pop(list));
+}
+
+static void test_push_pop_respectively_add_remove_at_the_end_of_the_list(void)
 {
    TEST_IGNORE();               // delete this line to run test
-   TEST_ASSERT_NOT_NULL(list);
+   list_push(list, 11);
+   list_push(list, 13);
+   TEST_ASSERT_EQUAL(13, list_pop(list));
+   TEST_ASSERT_EQUAL(11, list_pop(list));
 }
 
-static void test_list_is_empty_returns_true_when_empty(void)
+static void test_shift_gets_an_element_from_the_list(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT_TRUE(list_is_empty(list));
+   list_push(list, 17);
+   TEST_ASSERT_EQUAL(17, list_shift(list));
 }
 
-static void test_list_is_empty_returns_false_when_not_empty(void)
+static void test_shift_gets_first_element_from_the_list(void)
 {
    TEST_IGNORE();
-   // pre-populate list
-   ll_data_t data = 12;
-   list_push(list, data);
-   TEST_ASSERT_FALSE(list_is_empty(list));
+   list_push(list, 23);
+   list_push(list, 5);
+   TEST_ASSERT_EQUAL(23, list_shift(list));
+   TEST_ASSERT_EQUAL(5, list_shift(list));
 }
 
-static void test_list_push_with_multiple_items(void)
+static void test_unshift_adds_element_at_start_of_the_list(void)
 {
    TEST_IGNORE();
-   for (ll_data_t data = 14; data < 19; ++data) {
-      TEST_ASSERT_TRUE(list_push(list, data));
-   }
+   list_unshift(list, 23);
+   list_unshift(list, 5);
+   TEST_ASSERT_EQUAL(5, list_shift(list));
+   TEST_ASSERT_EQUAL(23, list_shift(list));
 }
 
-static void test_list_pop_returns_data_in_correct_order(void)
+static void test_pop_push_shift_and_unshift_can_be_used_in_any_order(void)
 {
    TEST_IGNORE();
-   // pre-populate list
-   for (ll_data_t data = 11; data <= 15; ++data) {
-      list_push(list, data);
-   }
-
-   for (ll_data_t data = 15; data >= 11; --data) {
-      TEST_ASSERT_EQUAL(data, list_pop(list));
-   }
-   TEST_ASSERT_TRUE(list_is_empty(list));
+   list_push(list, 1);
+   list_push(list, 2);
+   TEST_ASSERT_EQUAL(2, list_pop(list));
+   list_push(list, 3);
+   TEST_ASSERT_EQUAL(1, list_shift(list));
+   list_unshift(list, 4);
+   list_push(list, 5);
+   TEST_ASSERT_EQUAL(4, list_shift(list));
+   TEST_ASSERT_EQUAL(5, list_pop(list));
+   TEST_ASSERT_EQUAL(3, list_shift(list));
 }
 
-static void test_list_unshift_with_multiple_items(void)
+static void test_count_an_empty_list(void)
 {
    TEST_IGNORE();
-   for (ll_data_t data = 14; data < 19; ++data) {
-      TEST_ASSERT_TRUE(list_unshift(list, data));
-   }
+   TEST_ASSERT_EQUAL(0, list_count(list));
 }
 
-static void test_list_shift_returns_data_in_correct_order(void)
+static void test_count_a_list_with_items(void)
 {
    TEST_IGNORE();
-   // pre-populate list
-   for (ll_data_t data = 12; data <= 17; ++data) {
-      list_unshift(list, data);
-   }
-
-   for (ll_data_t data = 17; data >= 12; --data) {
-      TEST_ASSERT_EQUAL(data, list_shift(list));
-   }
-   TEST_ASSERT_TRUE(list_is_empty(list));
+   list_push(list, 37);
+   list_push(list, 1);
+   TEST_ASSERT_EQUAL(2, list_count(list));
 }
 
-static void test_pushed_data_can_be_shifted_in_original_order(void)
+static void test_count_is_correct_after_mutation(void)
 {
    TEST_IGNORE();
-   for (ll_data_t data = 16; data < 21; ++data) {
-      list_push(list, data);
-   }
-   for (ll_data_t data = 16; data < 21; ++data) {
-      TEST_ASSERT_EQUAL(data, list_shift(list));
-   }
-   TEST_ASSERT_TRUE(list_is_empty(list));
+   list_push(list, 31);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+   list_unshift(list, 43);
+   TEST_ASSERT_EQUAL(2, list_count(list));
+   list_shift(list);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+   list_pop(list);
+   TEST_ASSERT_EQUAL(0, list_count(list));
 }
 
-static void test_unshifted_data_can_be_popped_in_original_order(void)
+static void test_popping_to_empty_does_not_break_the_list(void)
 {
    TEST_IGNORE();
-   for (ll_data_t data = 16; data < 21; ++data) {
-      list_unshift(list, data);
-   }
-   for (ll_data_t data = 16; data < 21; ++data) {
-      TEST_ASSERT_EQUAL(data, list_pop(list));
-   }
-   TEST_ASSERT_TRUE(list_is_empty(list));
+   list_push(list, 41);
+   list_push(list, 59);
+   list_pop(list);
+   list_pop(list);
+   list_push(list, 47);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+   TEST_ASSERT_EQUAL(47, list_pop(list));
+}
+
+static void test_shifting_to_empty_does_not_break_the_list(void)
+{
+   TEST_IGNORE();
+   list_push(list, 41);
+   list_push(list, 59);
+   list_shift(list);
+   list_shift(list);
+   list_push(list, 47);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+   TEST_ASSERT_EQUAL(47, list_shift(list));
+}
+
+static void test_deletes_the_only_element(void)
+{
+   TEST_IGNORE();
+   list_push(list, 61);
+   list_delete(list, 61);
+   TEST_ASSERT_EQUAL(0, list_count(list));
+}
+
+static void test_deletes_the_element_with_the_specified_value_from_the_list(void)
+{
+   TEST_IGNORE();
+   list_push(list, 71);
+   list_push(list, 83);
+   list_push(list, 79);
+   list_delete(list, 83);
+   TEST_ASSERT_EQUAL(2, list_count(list));
+   TEST_ASSERT_EQUAL(79, list_pop(list));
+   TEST_ASSERT_EQUAL(71, list_shift(list));
+}
+
+static void test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail(void)
+{
+   TEST_IGNORE();
+   list_push(list, 71);
+   list_push(list, 83);
+   list_push(list, 79);
+   list_delete(list, 83);
+   TEST_ASSERT_EQUAL(2, list_count(list));
+   TEST_ASSERT_EQUAL(79, list_pop(list));
+   TEST_ASSERT_EQUAL(71, list_pop(list));
+}
+
+static void test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head(void)
+{
+   TEST_IGNORE();
+   list_push(list, 71);
+   list_push(list, 83);
+   list_push(list, 79);
+   list_delete(list, 83);
+   TEST_ASSERT_EQUAL(2, list_count(list));
+   TEST_ASSERT_EQUAL(71, list_shift(list));
+   TEST_ASSERT_EQUAL(79, list_shift(list));
+}
+
+static void test_deletes_the_first_of_two_elements(void)
+{
+   TEST_IGNORE();
+   list_push(list, 97);
+   list_push(list, 101);
+   list_delete(list, 97);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+   TEST_ASSERT_EQUAL(101, list_pop(list));
+}
+
+static void test_deletes_the_second_of_two_elements(void)
+{
+   TEST_IGNORE();
+   list_push(list, 97);
+   list_push(list, 101);
+   list_delete(list, 101);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+   TEST_ASSERT_EQUAL(97, list_pop(list));
+}
+
+static void test_delete_does_not_modify_the_list_if_the_element_is_not_found(void)
+{
+   TEST_IGNORE();
+   list_push(list, 89);
+   list_delete(list, 103);
+   TEST_ASSERT_EQUAL(1, list_count(list));
+}
+
+static void test_deletes_only_the_first_occurrence(void)
+{
+   TEST_IGNORE();
+   list_push(list, 73);
+   list_push(list, 9);
+   list_push(list, 9);
+   list_push(list, 107);
+   list_delete(list, 9);
+   TEST_ASSERT_EQUAL(3, list_count(list));
+   TEST_ASSERT_EQUAL(107, list_pop(list));
+   TEST_ASSERT_EQUAL(9, list_pop(list));
+   TEST_ASSERT_EQUAL(73, list_pop(list));
 }
 
 int main(void)
 {
    UnityBegin("test_linked_list.c");
 
-   RUN_TEST(test_list_create);
-   RUN_TEST(test_list_is_empty_returns_true_when_empty);
-   RUN_TEST(test_list_is_empty_returns_false_when_not_empty);
-   RUN_TEST(test_list_push_with_multiple_items);
-   RUN_TEST(test_list_pop_returns_data_in_correct_order);
-   RUN_TEST(test_list_unshift_with_multiple_items);
-   RUN_TEST(test_list_shift_returns_data_in_correct_order);
-   RUN_TEST(test_pushed_data_can_be_shifted_in_original_order);
-   RUN_TEST(test_pushed_data_can_be_shifted_in_original_order);
-   RUN_TEST(test_unshifted_data_can_be_popped_in_original_order);
+   RUN_TEST(test_pop_gets_element_from_the_list);
+   RUN_TEST(test_push_pop_respectively_add_remove_at_the_end_of_the_list);
+   RUN_TEST(test_shift_gets_an_element_from_the_list);
+   RUN_TEST(test_shift_gets_first_element_from_the_list);
+   RUN_TEST(test_unshift_adds_element_at_start_of_the_list);
+   RUN_TEST(test_pop_push_shift_and_unshift_can_be_used_in_any_order);
+   RUN_TEST(test_count_an_empty_list);
+   RUN_TEST(test_count_a_list_with_items);
+   RUN_TEST(test_count_is_correct_after_mutation);
+   RUN_TEST(test_popping_to_empty_does_not_break_the_list);
+   RUN_TEST(test_shifting_to_empty_does_not_break_the_list);
+   RUN_TEST(test_deletes_the_only_element);
+   RUN_TEST(test_deletes_the_element_with_the_specified_value_from_the_list);
+   RUN_TEST(test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail);
+   RUN_TEST(test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head);
+   RUN_TEST(test_deletes_the_first_of_two_elements);
+   RUN_TEST(test_deletes_the_second_of_two_elements);
+   RUN_TEST(test_delete_does_not_modify_the_list_if_the_element_is_not_found);
+   RUN_TEST(test_deletes_only_the_first_occurrence);
 
    return UnityEnd();
 }

--- a/exercises/practice/linked-list/test_linked_list.c
+++ b/exercises/practice/linked-list/test_linked_list.c
@@ -131,7 +131,8 @@ static void test_deletes_the_only_element(void)
    TEST_ASSERT_EQUAL(0, list_count(list));
 }
 
-static void test_deletes_the_element_with_the_specified_value_from_the_list(void)
+static void
+test_deletes_the_element_with_the_specified_value_from_the_list(void)
 {
    TEST_IGNORE();
    list_push(list, 71);
@@ -143,7 +144,9 @@ static void test_deletes_the_element_with_the_specified_value_from_the_list(void
    TEST_ASSERT_EQUAL(71, list_shift(list));
 }
 
-static void test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail(void)
+static void
+test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail
+(void)
 {
    TEST_IGNORE();
    list_push(list, 71);
@@ -155,7 +158,9 @@ static void test_deletes_the_element_with_the_specified_value_from_the_list_reas
    TEST_ASSERT_EQUAL(71, list_pop(list));
 }
 
-static void test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head(void)
+static void
+test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head
+(void)
 {
    TEST_IGNORE();
    list_push(list, 71);
@@ -187,7 +192,8 @@ static void test_deletes_the_second_of_two_elements(void)
    TEST_ASSERT_EQUAL(97, list_pop(list));
 }
 
-static void test_delete_does_not_modify_the_list_if_the_element_is_not_found(void)
+static void
+test_delete_does_not_modify_the_list_if_the_element_is_not_found(void)
 {
    TEST_IGNORE();
    list_push(list, 89);
@@ -226,8 +232,10 @@ int main(void)
    RUN_TEST(test_shifting_to_empty_does_not_break_the_list);
    RUN_TEST(test_deletes_the_only_element);
    RUN_TEST(test_deletes_the_element_with_the_specified_value_from_the_list);
-   RUN_TEST(test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail);
-   RUN_TEST(test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head);
+   RUN_TEST
+       (test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_tail);
+   RUN_TEST
+       (test_deletes_the_element_with_the_specified_value_from_the_list_reassigns_head);
    RUN_TEST(test_deletes_the_first_of_two_elements);
    RUN_TEST(test_deletes_the_second_of_two_elements);
    RUN_TEST(test_delete_does_not_modify_the_list_if_the_element_is_not_found);


### PR DESCRIPTION
Updates linked list to the current spec.

A question to consider when reviewing: two of the functions in the example implementation return values that are never checked. This is because while it is idiomatic in C to return these, the test specification does not have any need to specify them as expected - do we test them or leave them as-is?

1. The benefit of leaving them untested is conformance to the spec and leaving a wider solution space.
2. The benefit of testing them is communicating C idioms to the student and being slightly more specific. (however, see below)

The functions in question:

``` c
struct list_node *list_push(struct list * list, ll_data_t data);
struct list_node *list_unshift(struct list * list, ll_data_t data);
```

If we are to test them:
- Do we add this for every use of the mentioned functions or just some?
- What exactly do we test? The returned pointer can be tested for non-null and that the data value is correct... but does this realise the value from 2. above?