### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,8 +17,7 @@
   "files": {
     "solution": [
       "%{snake_slug}.c",
-      "%{snake_slug}.h",
-      "makefile"
+      "%{snake_slug}.h"
     ],
     "test": [
       "test_%{snake_slug}.c"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "acronym.c",
+      "acronym.h",
+      "makefile"
+    ],
+    "test": [
+      "test_acronym.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "acronym.c",
-      "acronym.h",
-      "makefile"
+      "acronym.h"
     ],
     "test": [
       "test_acronym.c"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "all_your_base.c",
-      "all_your_base.h",
-      "makefile"
+      "all_your_base.h"
     ],
     "test": [
       "test_all_your_base.c"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,8 +1,17 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "all_your_base.c",
+      "all_your_base.h",
+      "makefile"
+    ],
+    "test": [
+      "test_all_your_base.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   }
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "allergies.c",
-      "allergies.h",
-      "makefile"
+      "allergies.h"
     ],
     "test": [
       "test_allergies.c"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "allergies.c",
+      "allergies.h",
+      "makefile"
+    ],
+    "test": [
+      "test_allergies.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "anagram.c",
-      "anagram.h",
-      "makefile"
+      "anagram.h"
     ],
     "test": [
       "test_anagram.c"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "anagram.c",
+      "anagram.h",
+      "makefile"
+    ],
+    "test": [
+      "test_anagram.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "armstrong_numbers.c",
+      "armstrong_numbers.h",
+      "makefile"
+    ],
+    "test": [
+      "test_armstrong_numbers.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "armstrong_numbers.c",
-      "armstrong_numbers.h",
-      "makefile"
+      "armstrong_numbers.h"
     ],
     "test": [
       "test_armstrong_numbers.c"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "atbash_cipher.c",
-      "atbash_cipher.h",
-      "makefile"
+      "atbash_cipher.h"
     ],
     "test": [
       "test_atbash_cipher.c"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "atbash_cipher.c",
+      "atbash_cipher.h",
+      "makefile"
+    ],
+    "test": [
+      "test_atbash_cipher.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "beer_song.c",
-      "beer_song.h",
-      "makefile"
+      "beer_song.h"
     ],
     "test": [
       "test_beer_song.c"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "beer_song.c",
+      "beer_song.h",
+      "makefile"
+    ],
+    "test": [
+      "test_beer_song.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "binary_search_tree.c",
+      "binary_search_tree.h",
+      "makefile"
+    ],
+    "test": [
+      "test_binary_search_tree.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "binary_search_tree.c",
-      "binary_search_tree.h",
-      "makefile"
+      "binary_search_tree.h"
     ],
     "test": [
       "test_binary_search_tree.c"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "binary_search.c",
+      "binary_search.h",
+      "makefile"
+    ],
+    "test": [
+      "test_binary_search.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "binary_search.c",
-      "binary_search.h",
-      "makefile"
+      "binary_search.h"
     ],
     "test": [
       "test_binary_search.c"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "binary.c",
-      "binary.h",
-      "makefile"
+      "binary.h"
     ],
     "test": [
       "test_binary.c"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "binary.c",
+      "binary.h",
+      "makefile"
+    ],
+    "test": [
+      "test_binary.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "bob.c",
-      "bob.h",
-      "makefile"
+      "bob.h"
     ],
     "test": [
       "test_bob.c"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "bob.c",
+      "bob.h",
+      "makefile"
+    ],
+    "test": [
+      "test_bob.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "circular_buffer.c",
+      "circular_buffer.h",
+      "makefile"
+    ],
+    "test": [
+      "test_circular_buffer.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "circular_buffer.c",
-      "circular_buffer.h",
-      "makefile"
+      "circular_buffer.h"
     ],
     "test": [
       "test_circular_buffer.c"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "clock.c",
+      "clock.h",
+      "makefile"
+    ],
+    "test": [
+      "test_clock.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "clock.c",
-      "clock.h",
-      "makefile"
+      "clock.h"
     ],
     "test": [
       "test_clock.c"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "collatz_conjecture.c",
-      "collatz_conjecture.h",
-      "makefile"
+      "collatz_conjecture.h"
     ],
     "test": [
       "test_collatz_conjecture.c"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "collatz_conjecture.c",
+      "collatz_conjecture.h",
+      "makefile"
+    ],
+    "test": [
+      "test_collatz_conjecture.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "complex_numbers.c",
+      "complex_numbers.h",
+      "makefile"
+    ],
+    "test": [
+      "test_complex_numbers.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "complex_numbers.c",
-      "complex_numbers.h",
-      "makefile"
+      "complex_numbers.h"
     ],
     "test": [
       "test_complex_numbers.c"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "crypto_square.c",
-      "crypto_square.h",
-      "makefile"
+      "crypto_square.h"
     ],
     "test": [
       "test_crypto_square.c"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "crypto_square.c",
+      "crypto_square.h",
+      "makefile"
+    ],
+    "test": [
+      "test_crypto_square.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "darts.c",
-      "darts.h",
-      "makefile"
+      "darts.h"
     ],
     "test": [
       "test_darts.c"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "darts.c",
+      "darts.h",
+      "makefile"
+    ],
+    "test": [
+      "test_darts.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "diamond.c",
-      "diamond.h",
-      "makefile"
+      "diamond.h"
     ],
     "test": [
       "test_diamond.c"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "diamond.c",
+      "diamond.h",
+      "makefile"
+    ],
+    "test": [
+      "test_diamond.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "difference_of_squares.c",
+      "difference_of_squares.h",
+      "makefile"
+    ],
+    "test": [
+      "test_difference_of_squares.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "difference_of_squares.c",
-      "difference_of_squares.h",
-      "makefile"
+      "difference_of_squares.h"
     ],
     "test": [
       "test_difference_of_squares.c"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "etl.c",
+      "etl.h",
+      "makefile"
+    ],
+    "test": [
+      "test_etl.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "etl.c",
-      "etl.h",
-      "makefile"
+      "etl.h"
     ],
     "test": [
       "test_etl.c"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "gigasecond.c",
+      "gigasecond.h",
+      "makefile"
+    ],
+    "test": [
+      "test_gigasecond.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "gigasecond.c",
-      "gigasecond.h",
-      "makefile"
+      "gigasecond.h"
     ],
     "test": [
       "test_gigasecond.c"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "grade_school.c",
+      "grade_school.h",
+      "makefile"
+    ],
+    "test": [
+      "test_grade_school.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "grade_school.c",
-      "grade_school.h",
-      "makefile"
+      "grade_school.h"
     ],
     "test": [
       "test_grade_school.c"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "grains.c",
-      "grains.h",
-      "makefile"
+      "grains.h"
     ],
     "test": [
       "test_grains.c"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "grains.c",
+      "grains.h",
+      "makefile"
+    ],
+    "test": [
+      "test_grains.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hamming.c",
+      "hamming.h",
+      "makefile"
+    ],
+    "test": [
+      "test_hamming.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "hamming.c",
-      "hamming.h",
-      "makefile"
+      "hamming.h"
     ],
     "test": [
       "test_hamming.c"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "hello_world.c",
-      "hello_world.h",
-      "makefile"
+      "hello_world.h"
     ],
     "test": [
       "test_hello_world.c"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hello_world.c",
+      "hello_world.h",
+      "makefile"
+    ],
+    "test": [
+      "test_hello_world.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "isogram.c",
-      "isogram.h",
-      "makefile"
+      "isogram.h"
     ],
     "test": [
       "test_isogram.c"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "isogram.c",
+      "isogram.h",
+      "makefile"
+    ],
+    "test": [
+      "test_isogram.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "largest_series_product.c",
-      "largest_series_product.h",
-      "makefile"
+      "largest_series_product.h"
     ],
     "test": [
       "test_largest_series_product.c"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "largest_series_product.c",
+      "largest_series_product.h",
+      "makefile"
+    ],
+    "test": [
+      "test_largest_series_product.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "leap.c",
-      "leap.h",
-      "makefile"
+      "leap.h"
     ],
     "test": [
       "test_leap.c"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "leap.c",
+      "leap.h",
+      "makefile"
+    ],
+    "test": [
+      "test_leap.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "linked_list.c",
-      "linked_list.h",
-      "makefile"
+      "linked_list.h"
     ],
     "test": [
       "test_linked_list.c"

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "linked_list.c",
+      "linked_list.h",
+      "makefile"
+    ],
+    "test": [
+      "test_linked_list.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "list_ops.c",
-      "list_ops.h",
-      "makefile"
+      "list_ops.h"
     ],
     "test": [
       "test_list_ops.c"

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,8 +1,17 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "list_ops.c",
+      "list_ops.h",
+      "makefile"
+    ],
+    "test": [
+      "test_list_ops.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   }
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "luhn.c",
-      "luhn.h",
-      "makefile"
+      "luhn.h"
     ],
     "test": [
       "test_luhn.c"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "luhn.c",
+      "luhn.h",
+      "makefile"
+    ],
+    "test": [
+      "test_luhn.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "matching_brackets.c",
+      "matching_brackets.h",
+      "makefile"
+    ],
+    "test": [
+      "test_matching_brackets.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "matching_brackets.c",
-      "matching_brackets.h",
-      "makefile"
+      "matching_brackets.h"
     ],
     "test": [
       "test_matching_brackets.c"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "meetup.c",
+      "meetup.h",
+      "makefile"
+    ],
+    "test": [
+      "test_meetup.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "meetup.c",
-      "meetup.h",
-      "makefile"
+      "meetup.h"
     ],
     "test": [
       "test_meetup.c"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,8 +1,17 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "minesweeper.c",
+      "minesweeper.h",
+      "makefile"
+    ],
+    "test": [
+      "test_minesweeper.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "minesweeper.c",
-      "minesweeper.h",
-      "makefile"
+      "minesweeper.h"
     ],
     "test": [
       "test_minesweeper.c"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "nth_prime.c",
+      "nth_prime.h",
+      "makefile"
+    ],
+    "test": [
+      "test_nth_prime.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "nth_prime.c",
-      "nth_prime.h",
-      "makefile"
+      "nth_prime.h"
     ],
     "test": [
       "test_nth_prime.c"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "nucleotide_count.c",
-      "nucleotide_count.h",
-      "makefile"
+      "nucleotide_count.h"
     ],
     "test": [
       "test_nucleotide_count.c"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "nucleotide_count.c",
+      "nucleotide_count.h",
+      "makefile"
+    ],
+    "test": [
+      "test_nucleotide_count.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "palindrome_products.c",
-      "palindrome_products.h",
-      "makefile"
+      "palindrome_products.h"
     ],
     "test": [
       "test_palindrome_products.c"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "palindrome_products.c",
+      "palindrome_products.h",
+      "makefile"
+    ],
+    "test": [
+      "test_palindrome_products.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pangram.c",
+      "pangram.h",
+      "makefile"
+    ],
+    "test": [
+      "test_pangram.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "pangram.c",
-      "pangram.h",
-      "makefile"
+      "pangram.h"
     ],
     "test": [
       "test_pangram.c"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pascals_triangle.c",
+      "pascals_triangle.h",
+      "makefile"
+    ],
+    "test": [
+      "test_pascals_triangle.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "pascals_triangle.c",
-      "pascals_triangle.h",
-      "makefile"
+      "pascals_triangle.h"
     ],
     "test": [
       "test_pascals_triangle.c"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "perfect_numbers.c",
+      "perfect_numbers.h",
+      "makefile"
+    ],
+    "test": [
+      "test_perfect_numbers.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "perfect_numbers.c",
-      "perfect_numbers.h",
-      "makefile"
+      "perfect_numbers.h"
     ],
     "test": [
       "test_perfect_numbers.c"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "phone_number.c",
-      "phone_number.h",
-      "makefile"
+      "phone_number.h"
     ],
     "test": [
       "test_phone_number.c"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "phone_number.c",
+      "phone_number.h",
+      "makefile"
+    ],
+    "test": [
+      "test_phone_number.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pig_latin.c",
+      "pig_latin.h",
+      "makefile"
+    ],
+    "test": [
+      "test_pig_latin.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "pig_latin.c",
-      "pig_latin.h",
-      "makefile"
+      "pig_latin.h"
     ],
     "test": [
       "test_pig_latin.c"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "prime_factors.c",
+      "prime_factors.h",
+      "makefile"
+    ],
+    "test": [
+      "test_prime_factors.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "prime_factors.c",
-      "prime_factors.h",
-      "makefile"
+      "prime_factors.h"
     ],
     "test": [
       "test_prime_factors.c"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pythagorean_triplet.c",
+      "pythagorean_triplet.h",
+      "makefile"
+    ],
+    "test": [
+      "test_pythagorean_triplet.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "pythagorean_triplet.c",
-      "pythagorean_triplet.h",
-      "makefile"
+      "pythagorean_triplet.h"
     ],
     "test": [
       "test_pythagorean_triplet.c"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "queen_attack.c",
+      "queen_attack.h",
+      "makefile"
+    ],
+    "test": [
+      "test_queen_attack.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "queen_attack.c",
-      "queen_attack.h",
-      "makefile"
+      "queen_attack.h"
     ],
     "test": [
       "test_queen_attack.c"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rail_fence_cipher.c",
+      "rail_fence_cipher.h",
+      "makefile"
+    ],
+    "test": [
+      "test_rail_fence_cipher.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "rail_fence_cipher.c",
-      "rail_fence_cipher.h",
-      "makefile"
+      "rail_fence_cipher.h"
     ],
     "test": [
       "test_rail_fence_cipher.c"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "raindrops.c",
-      "raindrops.h",
-      "makefile"
+      "raindrops.h"
     ],
     "test": [
       "test_raindrops.c"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "raindrops.c",
+      "raindrops.h",
+      "makefile"
+    ],
+    "test": [
+      "test_raindrops.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rational_numbers.c",
+      "rational_numbers.h",
+      "makefile"
+    ],
+    "test": [
+      "test_rational_numbers.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "rational_numbers.c",
-      "rational_numbers.h",
-      "makefile"
+      "rational_numbers.h"
     ],
     "test": [
       "test_rational_numbers.c"

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,8 +1,17 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "react.c",
+      "react.h",
+      "makefile"
+    ],
+    "test": [
+      "test_react.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   }
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "react.c",
-      "react.h",
-      "makefile"
+      "react.h"
     ],
     "test": [
       "test_react.c"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "resistor_color_duo.c",
+      "resistor_color_duo.h",
+      "makefile"
+    ],
+    "test": [
+      "test_resistor_color_duo.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "resistor_color_duo.c",
-      "resistor_color_duo.h",
-      "makefile"
+      "resistor_color_duo.h"
     ],
     "test": [
       "test_resistor_color_duo.c"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "resistor_color_trio.c",
+      "resistor_color_trio.h",
+      "makefile"
+    ],
+    "test": [
+      "test_resistor_color_trio.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "resistor_color_trio.c",
-      "resistor_color_trio.h",
-      "makefile"
+      "resistor_color_trio.h"
     ],
     "test": [
       "test_resistor_color_trio.c"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "resistor_color.c",
+      "resistor_color.h",
+      "makefile"
+    ],
+    "test": [
+      "test_resistor_color.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "resistor_color.c",
-      "resistor_color.h",
-      "makefile"
+      "resistor_color.h"
     ],
     "test": [
       "test_resistor_color.c"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "rna_transcription.c",
-      "rna_transcription.h",
-      "makefile"
+      "rna_transcription.h"
     ],
     "test": [
       "test_rna_transcription.c"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rna_transcription.c",
+      "rna_transcription.h",
+      "makefile"
+    ],
+    "test": [
+      "test_rna_transcription.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "robot_simulator.c",
+      "robot_simulator.h",
+      "makefile"
+    ],
+    "test": [
+      "test_robot_simulator.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "robot_simulator.c",
-      "robot_simulator.h",
-      "makefile"
+      "robot_simulator.h"
     ],
     "test": [
       "test_robot_simulator.c"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "roman_numerals.c",
-      "roman_numerals.h",
-      "makefile"
+      "roman_numerals.h"
     ],
     "test": [
       "test_roman_numerals.c"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "roman_numerals.c",
+      "roman_numerals.h",
+      "makefile"
+    ],
+    "test": [
+      "test_roman_numerals.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "run_length_encoding.c",
+      "run_length_encoding.h",
+      "makefile"
+    ],
+    "test": [
+      "test_run_length_encoding.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "run_length_encoding.c",
-      "run_length_encoding.h",
-      "makefile"
+      "run_length_encoding.h"
     ],
     "test": [
       "test_run_length_encoding.c"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "saddle_points.c",
-      "saddle_points.h",
-      "makefile"
+      "saddle_points.h"
     ],
     "test": [
       "test_saddle_points.c"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "saddle_points.c",
+      "saddle_points.h",
+      "makefile"
+    ],
+    "test": [
+      "test_saddle_points.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "say.c",
-      "say.h",
-      "makefile"
+      "say.h"
     ],
     "test": [
       "test_say.c"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "say.c",
+      "say.h",
+      "makefile"
+    ],
+    "test": [
+      "test_say.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "scrabble_score.c",
-      "scrabble_score.h",
-      "makefile"
+      "scrabble_score.h"
     ],
     "test": [
       "test_scrabble_score.c"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "scrabble_score.c",
+      "scrabble_score.h",
+      "makefile"
+    ],
+    "test": [
+      "test_scrabble_score.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "secret_handshake.c",
+      "secret_handshake.h",
+      "makefile"
+    ],
+    "test": [
+      "test_secret_handshake.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "secret_handshake.c",
-      "secret_handshake.h",
-      "makefile"
+      "secret_handshake.h"
     ],
     "test": [
       "test_secret_handshake.c"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "series.c",
-      "series.h",
-      "makefile"
+      "series.h"
     ],
     "test": [
       "test_series.c"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "series.c",
+      "series.h",
+      "makefile"
+    ],
+    "test": [
+      "test_series.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "sieve.c",
-      "sieve.h",
-      "makefile"
+      "sieve.h"
     ],
     "test": [
       "test_sieve.c"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sieve.c",
+      "sieve.h",
+      "makefile"
+    ],
+    "test": [
+      "test_sieve.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "space_age.c",
-      "space_age.h",
-      "makefile"
+      "space_age.h"
     ],
     "test": [
       "test_space_age.c"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "space_age.c",
+      "space_age.h",
+      "makefile"
+    ],
+    "test": [
+      "test_space_age.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "square_root.c",
-      "square_root.h",
-      "makefile"
+      "square_root.h"
     ],
     "test": [
       "test_square_root.c"

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "square_root.c",
+      "square_root.h",
+      "makefile"
+    ],
+    "test": [
+      "test_square_root.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "sublist.c",
-      "sublist.h",
-      "makefile"
+      "sublist.h"
     ],
     "test": [
       "test_sublist.c"

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,8 +1,17 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sublist.c",
+      "sublist.h",
+      "makefile"
+    ],
+    "test": [
+      "test_sublist.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   }
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "sum_of_multiples.c",
-      "sum_of_multiples.h",
-      "makefile"
+      "sum_of_multiples.h"
     ],
     "test": [
       "test_sum_of_multiples.c"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sum_of_multiples.c",
+      "sum_of_multiples.h",
+      "makefile"
+    ],
+    "test": [
+      "test_sum_of_multiples.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "triangle.c",
-      "triangle.h",
-      "makefile"
+      "triangle.h"
     ],
     "test": [
       "test_triangle.c"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "triangle.c",
+      "triangle.h",
+      "makefile"
+    ],
+    "test": [
+      "test_triangle.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "two_bucket.c",
-      "two_bucket.h",
-      "makefile"
+      "two_bucket.h"
     ],
     "test": [
       "test_two_bucket.c"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "two_bucket.c",
+      "two_bucket.h",
+      "makefile"
+    ],
+    "test": [
+      "test_two_bucket.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "two_fer.c",
-      "two_fer.h",
-      "makefile"
+      "two_fer.h"
     ],
     "test": [
       "test_two_fer.c"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "two_fer.c",
+      "two_fer.h",
+      "makefile"
+    ],
+    "test": [
+      "test_two_fer.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "word_count.c",
-      "word_count.h",
-      "makefile"
+      "word_count.h"
     ],
     "test": [
       "test_word_count.c"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "word_count.c",
+      "word_count.h",
+      "makefile"
+    ],
+    "test": [
+      "test_word_count.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -3,8 +3,7 @@
   "files": {
     "solution": [
       "wordy.c",
-      "wordy.h",
-      "makefile"
+      "wordy.h"
     ],
     "test": [
       "test_wordy.c"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,9 +1,18 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "wordy.c",
+      "wordy.h",
+      "makefile"
+    ],
+    "test": [
+      "test_wordy.c"
+    ],
+    "example": [
+      ".meta/example.c",
+      ".meta/example.h"
+    ]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

