### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "b5694b00-7d91-4c1c-945b-dd2e5ef10dd4",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing C locally",
+      "blurb": "Learn how to install C locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "b8f29dfc-2b4f-4d76-83a5-8662aea2c1f0",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn C",
+      "blurb": "An overview of how to get started from scratch with C"
+    },
+    {
+      "uuid": "0c94e765-d8a7-42cb-bb24-af15dbe5665c",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the C track",
+      "blurb": "Learn how to test your C exercises on Exercism"
+    },
+    {
+      "uuid": "60c0b429-0a18-425b-913f-b1c6165058ef",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful C resources",
+      "blurb": "A collection of useful resources to help you master C"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
