### PR TITLE
Remove canonical data syncer reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 bin/configlet
 bin/configlet.exe
-bin/canonical_data_syncer
 build/
 **/*.out
 **/*.o


### PR DESCRIPTION
The `fetch-canonical-data-syncer` script is obsolete as canonical data syncing is now built into `configlet`.

See https://github.com/exercism/configlet/issues/124