### PR TITLE
hamming: remove duplicate key

### DIFF
--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -33,9 +33,6 @@ comment = "reimplemented"
 [dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
 description = "disallow second strand longer"
 
-[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
-description = "disallow second strand longer"
-
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
 include = false


### PR DESCRIPTION
I think this was introduced because of the changes to remove `incude = true`

Either way, duplicate keys cause configlet to throw an exception, so this change prevents that also