### PR TITLE
Rename a typedef in list-ops

### DIFF
--- a/exercises/practice/list-ops/list_ops.h
+++ b/exercises/practice/list-ops/list_ops.h
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-typedef int list_value_t;
+typedef int list_element_t;
 
 typedef struct {
    size_t length;


### PR DESCRIPTION
Renamed list_value_t to list_element_t in the header of the list-ops exercise