### PR TITLE
robot-simulator: remove blank source_url

### DIFF
--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -25,6 +25,5 @@
       ".meta/example.c"
     ]
   },
-  "source": "Inspired by an interview question at a famous company.",
-  "source_url": ""
+  "source": "Inspired by an interview question at a famous company."
 }


### PR DESCRIPTION
Configlet is failing in CI because it expects a valid value for `source_url` (https://github.com/exercism/c/runs/3667565364?check_suite_focus=true).

Same solution was used in #688 