### PR TITLE
grade-school: fix typo in tests.toml

### DIFF
--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -8,7 +8,7 @@ description = "Adding a student adds them to the sorted roster"
 [c125dab7-2a53-492f-a99a-56ad511940d8]
 description = "A student can't be in two different grades"
 include = false
-comment = "Reimplimented"
+comment = "Reimplemented"
 
 [a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1]
 description = "A student can only be added to the same grade in the roster once"


### PR DESCRIPTION
Another minor typo I spotted while working on https://github.com/exercism/problem-specifications/pull/1837