### PR TITLE
Update test_say.c  Fixed memory leaks

### DIFF
--- a/exercises/practice/say/test_say.c
+++ b/exercises/practice/say/test_say.c
@@ -12,7 +12,7 @@ void tearDown(void)
 {
    if (ans)
       free(ans);
-   ans = NULL;   
+   ans = NULL;
 }
 
 static void test_zero(void)

--- a/exercises/practice/say/test_say.c
+++ b/exercises/practice/say/test_say.c
@@ -2,164 +2,139 @@
 #include "say.h"
 #include <stdlib.h>
 
+static char *ans = NULL;
+
 void setUp(void)
 {
 }
 
 void tearDown(void)
 {
+   if (ans)
+      free(ans);
+   ans = NULL;   
 }
 
 static void test_zero(void)
 {
-   char *ans = NULL;
    int res = say(0, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("zero", ans);
-   free(ans);
 }
 
 static void test_one(void)
 {
    TEST_IGNORE();   // delete this line to run test
-   char *ans = NULL;
    int res = say(1, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one", ans);
-   free(ans);
 }
 
 static void test_fourteen(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(14, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("fourteen", ans);
-   free(ans);
 }
 
 static void test_twenty(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(20, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("twenty", ans);
-   free(ans);
 }
 
 static void test_twenty_two(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(22, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("twenty-two", ans);
-   free(ans);
 }
 
 static void test_one_hundred(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(100, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one hundred", ans);
-   free(ans);
 }
 
 static void test_one_hundred_twenty_three(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(123, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one hundred twenty-three", ans);
-   free(ans);
 }
 
 static void test_one_thousand(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(1000, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one thousand", ans);
-   free(ans);
 }
 
 static void test_one_thousand_two_hundred_thirty_four(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(1234, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one thousand two hundred thirty-four", ans);
-   free(ans);
 }
 
 static void test_one_million(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(1000000, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one million", ans);
-   free(ans);
 }
 
 static void test_one_million_two_thousand_three_hundred_forty_five(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(1002345, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one million two thousand three hundred "
                             "forty-five",
                             ans);
-   free(ans);
 }
 
 static void test_one_billion(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(1000000000, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("one billion", ans);
-   free(ans);
 }
 
 static void test_a_big_number(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(987654321123, &ans);
    TEST_ASSERT_EQUAL_INT(0, res);
    TEST_ASSERT_EQUAL_STRING("nine hundred eighty-seven billion six hundred "
                             "fifty-four million three hundred twenty-one "
                             "thousand one hundred twenty-three",
                             ans);
-   free(ans);
 }
 
 static void test_numbers_below_zero_are_out_of_range(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(-1, &ans);
    TEST_ASSERT_EQUAL_INT(-1, res);
-   free(ans);
 }
 
 static void test_numbers_above_999_999_999_999_are_out_of_range(void)
 {
    TEST_IGNORE();
-   char *ans = NULL;
    int res = say(1000000000000, &ans);
    TEST_ASSERT_EQUAL_INT(-1, res);
-   free(ans);
 }
 
 int main(void)


### PR DESCRIPTION
`ans` would not be freed on failed `TEST_ASSERT_XXX`, according to `make memcheck` on my local machine. Used `test_phone_number.c` as my guide for the fix.