### PR TITLE
Update to test_roman_numerals.c Fixed memory leaks

### DIFF
--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -9,6 +9,9 @@ void setUp(void)
 
 void tearDown(void)
 {
+   if (result)
+      free(result);
+   result = NULL;
 }
 
 static void check_conversion(int number, char *expected)

--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -2,6 +2,7 @@
 #include "roman_numerals.h"
 #include <stdlib.h>
 
+static char *result = NULL;
 void setUp(void)
 {
 }
@@ -12,9 +13,8 @@ void tearDown(void)
 
 static void check_conversion(int number, char *expected)
 {
-   char *result = to_roman_numeral(number);
+   result = to_roman_numeral(number);
    TEST_ASSERT_EQUAL_STRING(expected, result);
-   free(result);
 }
 
 static void test_1_is_I(void)


### PR DESCRIPTION
In current configuration `make memcheck` reported direct memory leak for failed `TEST_ASSERT_EQUAL_STRING` on my local machine (Ubuntu WSL.) With the updated configuration there are no memory leaks. Specifying `if (result) free result;` generated an error for attempted double free of `result`, so it must be getting successfully freed somewhere as long as the ASSERT passes. **Edit** I had forgotten to set `result` to NULL, which seems to have led to the double-free.