### PR TITLE
Update test_acronym.c Fixed memory leaks

### DIFF
--- a/exercises/practice/acronym/test_acronym.c
+++ b/exercises/practice/acronym/test_acronym.c
@@ -3,19 +3,22 @@
 #include <stdlib.h>
 #include <string.h>
 
+static char *actual = NULL;
 void setUp(void)
 {
 }
 
 void tearDown(void)
 {
+   if (actual)
+      free(actual);
+   actual = NULL;
 }
 
 static void check_abbreviation(char *phrase, char *expected)
 {
-   char *actual = abbreviate(phrase);
+   actual = abbreviate(phrase);
    TEST_ASSERT_EQUAL_STRING(expected, actual);
-   free(actual);
 }
 
 static void test_null_string(void)


### PR DESCRIPTION
`make memcheck` reported direct memory leak on failed `TEST_ASSERT_EQUAL_STRING` on my local machine (Ubuntu WSL.) Now has no memory leaks.