### PR TITLE
Improve "diamond" by adding a cleanup function.

### DIFF
--- a/exercises/practice/diamond/.meta/example.c
+++ b/exercises/practice/diamond/.meta/example.c
@@ -45,3 +45,10 @@ char **make_diamond(const char letter)
 
    return diamond;
 }
+
+void free_diamond(char **diamond)
+{
+    free(diamond[0]);
+    free(diamond);
+}
+

--- a/exercises/practice/diamond/.meta/example.h
+++ b/exercises/practice/diamond/.meta/example.h
@@ -2,5 +2,6 @@
 #define DIAMOND_H
 
 char **make_diamond(const char letter);
+void free_diamond(char **diamond);
 
 #endif

--- a/exercises/practice/diamond/diamond.h
+++ b/exercises/practice/diamond/diamond.h
@@ -2,5 +2,6 @@
 #define DIAMOND_H
 
 char **make_diamond(const char letter);
+void free_diamond(char **diamond);
 
 #endif

--- a/exercises/practice/diamond/test_diamond.c
+++ b/exercises/practice/diamond/test_diamond.c
@@ -12,19 +12,13 @@ void tearDown(void)
 {
 }
 
-static void free_all(char **diamond)
-{
-   free(diamond[0]);
-   free(diamond);
-}
-
 static void test_rows_degenerate_case_with_a_single_a_row(void)
 {
    const char letter = 'A';
    const char *expected[] = { "A" };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
-   free_all(diamond);
+   free_diamond(diamond);
 }
 
 static void
@@ -41,7 +35,7 @@ test_rows_degenerate_case_with_no_row_with_3_distinct_groups_of_spaces(void)
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
-   free_all(diamond);
+   free_diamond(diamond);
 }
 
 static void
@@ -60,7 +54,7 @@ test_rows_smallest_non_degenerate_case_with_odd_diamond_side_length(void)
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
-   free_all(diamond);
+   free_diamond(diamond);
 }
 
 static void
@@ -81,7 +75,7 @@ test_rows_smallest_non_degenerate_case_with_even_diamond_side_length(void)
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
-   free_all(diamond);
+   free_diamond(diamond);
 }
 
 static void test_rows_largest_possible_diamond(void)
@@ -145,7 +139,7 @@ static void test_rows_largest_possible_diamond(void)
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
-   free_all(diamond);
+   free_diamond(diamond);
 }
 
 int main(void)


### PR DESCRIPTION
As discussed in issue #758 this exercise currently requires the function `make_diamond()` to return an array of `char *` where the first element is a dynamically allocated string, and the other elements point to substrings of that first element.
That might be clever because it avoids unnecessary allocations, but it's not obvious.

This PR adds a second function `free_diamond()` as part of the exercise.
That way the students can choose how the result is allocated and are responsible for deallocating it completely.
That should be a little bit easier to understand. And it still allows the "clever" solution.