### PR TITLE
lychee-action: add user-agent to prevent 403s

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
         uses: lycheeverse/lychee-action@f1da3291e1d03cbe11a413ae9f16b62fec99e6b6
         id: lychee
         with:
-          args: --no-progress **/*.md **/*.html
+          args: -u 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36' --no-progress **/*.md **/*.html
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
         uses: lycheeverse/lychee-action@f1da3291e1d03cbe11a413ae9f16b62fec99e6b6
         id: lychee
         with:
-          args: -u 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36' --no-progress **/*.md **/*.html
+          args: --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36" --no-progress **/*.md **/*.html
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
As discussed on #782 a simple User Agent fix would help resolve build errors for lychee-actions

```bash
[c] curl -I -H 'user-agent: lychee/0.9.0' https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
HTTP/2 403
x-azure-ref: 0OKFVYgAAAAB6pZomkF2ESoOnq6KwAjElQk9NMDJFREdFMDkyMQA1OTZkNzhhMi1jYTVmLTQ3OWQtYmNkYy0wODM1ODMzMTc0YjI=
accept-ranges: bytes
date: Tue, 12 Apr 2022 15:56:40 GMT
via: 1.1 varnish
x-served-by: cache-bom4746-BOM
x-cache: MISS
x-cache-hits: 0
x-timer: S1649779001.872762,VS0,VE5
strict-transport-security: max-age=31557600

[c] curl -I -H 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36' https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
HTTP/2 200
cache-control: private, no-store
content-type: text/html; charset=utf-8
etag: "408f5-KOfRpV8rcRjxUwjkDLLT1YsGLoc"
set-cookie: _csrf=avAJ44a2tx7mFbqNUwdny77i; Path=/; HttpOnly; Secure; SameSite=Lax
access-control-allow-origin: *
content-security-policy: default-src 'none';prefetch-src 'self';connect-src 'self';font-src 'self' data: githubdocs.azureedge.net;img-src 'self' data: github.githubassets.com githubdocs.azureedge.net placehold.it *.githubusercontent.com github.com;object-src 'self';script-src 'self';frame-src https://graphql.github.com/ https://www.youtube-nocookie.com;style-src 'self' 'unsafe-inline';child-src 'self'
x-dns-prefetch-control: off
expect-ct: max-age=0
x-frame-options: SAMEORIGIN
x-download-options: noopen
x-content-type-options: nosniff
x-permitted-cross-domain-policies: none
referrer-policy: strict-origin-when-cross-origin
x-xss-protection: 0
x-powered-by: Next.js
x-azure-ref: 0W6FVYgAAAABWPef981jxRLLp9JML5swnQk9NMDJFREdFMDkyMQA1OTZkNzhhMi1jYTVmLTQ3OWQtYmNkYy0wODM1ODMzMTc0YjI=
accept-ranges: bytes
date: Tue, 12 Apr 2022 15:57:16 GMT
via: 1.1 varnish
x-served-by: cache-bom4732-BOM
x-cache: CONFIG_NOCACHE, MISS
x-cache-hits: 0
x-timer: S1649779036.961168,VS0,VE373
vary: Accept-Encoding
strict-transport-security: max-age=31557600
content-length: 264437
```