### PR TITLE
Updated call to assert to provide a better error

### DIFF
--- a/exercises/practice/pig-latin/test_pig_latin.c
+++ b/exercises/practice/pig-latin/test_pig_latin.c
@@ -17,7 +17,7 @@ void tearDown(void)
 static void check_transate(const char *phrase, const char *expected)
 {
    res = translate(phrase);
-   TEST_ASSERT_EQUAL_STRING(res, expected);
+   TEST_ASSERT_EQUAL_STRING(expected, res);
 }
 
 static void test_word_beginning_with_a(void)


### PR DESCRIPTION
The order of the expected and the actual strings were revered giving a
error message where the output of the function was referred to as
expected.

Ex:

```
test_word_beginning_with_a:FAIL: Expected 'apple' Was 'appleay'
```

Now the message is:

```
test_word_beginning_with_a:FAIL: Expected 'appleay' Was 'apple'
```

Note: in both these examples the function under test just retunes the
input string.