### PR TITLE
Use (void) for create_reactor prototype

### DIFF
--- a/exercises/practice/react/.meta/example.c
+++ b/exercises/practice/react/.meta/example.c
@@ -38,7 +38,7 @@ struct cell {
    int callbacks_issued;
 };
 
-struct reactor *create_reactor()
+struct reactor *create_reactor(void)
 {
    return calloc(1, sizeof(struct reactor));
 }

--- a/exercises/practice/react/react.h
+++ b/exercises/practice/react/react.h
@@ -7,7 +7,7 @@ struct cell;
 typedef int (*compute1)(int);
 typedef int (*compute2)(int, int);
 
-struct reactor *create_reactor();
+struct reactor *create_reactor(void);
 // destroy_reactor should free all cells created under that reactor.
 void destroy_reactor(struct reactor *);
 


### PR DESCRIPTION
I was reviewing a submission for `reactor` and noticed that it used an empty argument list (`()`) instead of `(void)` for the `create_reactor` prototype and traced this back to the provided template.

This changes the template and sample solution to use the more correct `(void)`.

For more background, please see https://stackoverflow.com/questions/51032/is-there-a-difference-between-foovoid-and-foo-in-c-or-c