### PR TITLE
grains: Improve the tests with an _EQUAL_ macro.

### DIFF
--- a/exercises/practice/grains/test_grains.c
+++ b/exercises/practice/grains/test_grains.c
@@ -11,61 +11,61 @@ void tearDown(void)
 
 static void test_square_1(void)
 {
-   TEST_ASSERT(1ull == square(1));
+   TEST_ASSERT_EQUAL_UINT64(1ull, square(1));
 }
 
 static void test_square_2(void)
 {
    TEST_IGNORE();   // delete this line to run test
-   TEST_ASSERT(2ull == square(2));
+   TEST_ASSERT_EQUAL_UINT64(2ull, square(2));
 }
 
 static void test_square_3(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(4ull == square(3));
+   TEST_ASSERT_EQUAL_UINT64(4ull, square(3));
 }
 
 static void test_square_4(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(8ull == square(4));
+   TEST_ASSERT_EQUAL_UINT64(8ull, square(4));
 }
 
 static void test_square_16(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(32768ull == square(16));
+   TEST_ASSERT_EQUAL_UINT64(32768ull, square(16));
 }
 
 static void test_square_32(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(2147483648ull == square(32));
+   TEST_ASSERT_EQUAL_UINT64(2147483648ull, square(32));
 }
 
 static void test_square_64(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(9223372036854775808ull == square(64));
+   TEST_ASSERT_EQUAL_UINT64(9223372036854775808ull, square(64));
 }
 
 static void test_square_0_does_not_exist(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(0 == square(0));
+   TEST_ASSERT_EQUAL_UINT64(0, square(0));
 }
 
 static void test_square_greater_than_64_does_not_exist(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(0 == square(65));
+   TEST_ASSERT_EQUAL_UINT64(0, square(65));
 }
 
 static void test_total(void)
 {
    TEST_IGNORE();
-   TEST_ASSERT(18446744073709551615ull == total());
+   TEST_ASSERT_EQUAL_UINT64(18446744073709551615ull, total());
 }
 
 int main(void)


### PR DESCRIPTION
Currently the tests compare the expected and actual result with `==` and
call `TEST_ASSERT()` which leads to error messages like
"FAIL: Expression Evaluated To FALSE".
With `TEST_ASSERT_EQUAL_UINT64()` the error message is much easier to
understand:
"FAIL: Expected 18446744073709551615 Was 18446744073709551614"