### PR TITLE
gigasecond: update tests

### DIFF
--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
@@ -16,3 +23,8 @@ description = "full time specified"
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false
+comment = "Current interface passes input by value, so this test has no meaning"

--- a/exercises/practice/gigasecond/test_gigasecond.c
+++ b/exercises/practice/gigasecond/test_gigasecond.c
@@ -14,10 +14,10 @@ static inline size_t is_leap_year(int year)
 
 static inline time_t days_from_1ad(int year)
 {
-   --year;   // The gregorian calander is without a year 0. This is years from
+   --year;   // The gregorian calendar is without a year 0. This is years from
              // 1AD.
    // Little complex, add a day for all of the leap years
-   // This is a quarter of the days since 0 execpt one in a hundred are lost
+   // This is a quarter of the days since 0 except one in a hundred are lost
    // except 1 in 400 are gained ... simple.
    return 365 * year + (year / 400) - (year / 100) + (year / 4);
 }


### PR DESCRIPTION
Adds test as excluded, see comment in `tests.toml`.

Also fixes 2 typos in the comments in the tests