### PR TITLE
matching-brackets: update test

### DIFF
--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -3,6 +3,7 @@
 # Regenerating this file via `configlet sync` will:
 # - Recreate every `description` key/value pair
 # - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
 # - Preserve any other key/value pair
 #
 # As user-added comments (using the # character) will be removed when this file
@@ -46,6 +47,9 @@ description = "unpaired and nested brackets"
 
 [a0205e34-c2ac-49e6-a88a-899508d7d68e]
 description = "paired and wrong nested brackets"
+
+[1d5c093f-fc84-41fb-8c2a-e052f9581602]
+description = "paired and wrong nested brackets but innermost are correct"
 
 [ef47c21b-bcfd-4998-844c-7ad5daad90a8]
 description = "paired and incomplete brackets"

--- a/exercises/practice/matching-brackets/test_matching_brackets.c
+++ b/exercises/practice/matching-brackets/test_matching_brackets.c
@@ -100,6 +100,14 @@ static void test_paired_and_wrong_nested_brackets(void)
    TEST_ASSERT_FALSE(is_paired(input));
 }
 
+static void
+test_paired_and_wrong_nested_brackets_but_innermost_are_correct(void)
+{
+   TEST_IGNORE();
+   const char *input = "[({}])";
+   TEST_ASSERT_FALSE(is_paired(input));
+}
+
 static void test_paired_and_incomplete_brackets(void)
 {
    TEST_IGNORE();
@@ -160,6 +168,7 @@ int main(void)
    RUN_TEST(test_unopened_closing_brackets);
    RUN_TEST(test_unpaired_and_nested_brackets);
    RUN_TEST(test_paired_and_wrong_nested_brackets);
+   RUN_TEST(test_paired_and_wrong_nested_brackets_but_innermost_are_correct);
    RUN_TEST(test_paired_and_incomplete_brackets);
    RUN_TEST(test_too_many_closing_brackets);
    RUN_TEST(test_early_unexpected_brackets);


### PR DESCRIPTION
Adds new test `test_paired_and_wrong_nested_brackets_but_innermost_are_correct()`, per the updated problem spec