### PR TITLE
roman-numerals: update tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/example.c
+++ b/exercises/practice/roman-numerals/.meta/example.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #define NUM_OF_ELEMENTS(a) (sizeof(a) / sizeof(a[0]))
-#define MAX_NUMERAL_LENGTH (8)
+#define MAX_NUMERAL_LENGTH (10)
 
 typedef struct {
    char *numeral;

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -80,3 +80,9 @@ description = "666 is DCLXVI"
 
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 static char *result = NULL;
+
 void setUp(void)
 {
 }
@@ -163,6 +164,18 @@ static void test_1666_is_MDCLXVI(void)
    check_conversion(1666, "MDCLXVI");
 }
 
+static void test_3001_is_MMMI(void)
+{
+   TEST_IGNORE();
+   check_conversion(3001, "MMMI");
+}
+
+static void test_3999_is_MMMCMXCIX(void)
+{
+   TEST_IGNORE();
+   check_conversion(3999, "MMMCMXCIX");
+}
+
 int main(void)
 {
    UnityBegin("test_roman_numerals.c");
@@ -191,6 +204,8 @@ int main(void)
    RUN_TEST(test_166_is_CLXVI);
    RUN_TEST(test_666_is_DCLXVI);
    RUN_TEST(test_1666_is_MDCLXVI);
+   RUN_TEST(test_3001_is_MMMI);
+   RUN_TEST(test_3999_is_MMMCMXCIX);
 
    return UnityEnd();
 }


### PR DESCRIPTION
Adds tests per the updated problem spec.

This one required a small change to the example implementation to use a longer string when constructing the return value as the maximum expected return value is now longer with the new tests.