### PR TITLE
Binary Search - Do not expect a non-const pointer from a const pointer

### DIFF
--- a/exercises/practice/binary-search/.meta/example.c
+++ b/exercises/practice/binary-search/.meta/example.c
@@ -1,6 +1,6 @@
 #include "binary_search.h"
 
-int *binary_search(const int value, const int *arr, const size_t length)
+const int *binary_search(const int value, const int *arr, const size_t length)
 {
    if (0 == length || NULL == arr) {
       return NULL;
@@ -14,7 +14,7 @@ int *binary_search(const int value, const int *arr, const size_t length)
       } else if (*mid < value) {
          low = mid + 1;
       } else {
-         return (int *)mid;
+         return mid;
       }
    }
    return NULL;

--- a/exercises/practice/binary-search/.meta/example.h
+++ b/exercises/practice/binary-search/.meta/example.h
@@ -3,6 +3,6 @@
 
 #include <stddef.h>
 
-int *binary_search(int value, const int *arr, size_t length);
+const int *binary_search(int value, const int *arr, size_t length);
 
 #endif

--- a/exercises/practice/binary-search/binary_search.h
+++ b/exercises/practice/binary-search/binary_search.h
@@ -3,6 +3,6 @@
 
 #include <stddef.h>
 
-int *binary_search(int value, const int *arr, size_t length);
+const int *binary_search(int value, const int *arr, size_t length);
 
 #endif


### PR DESCRIPTION
Currently in `binary-search` we pass an array via a `const` pointer but then expect a non-`const` pointer back. This requires an illegal cast (removal of `const`) as seen in our example.

This changes the return type from `int *` to `const int *` so that no cast is required.