### PR TITLE
Reorder parameters for consistency

### DIFF
--- a/exercises/practice/high-scores/test_high_scores.c
+++ b/exercises/practice/high-scores/test_high_scores.c
@@ -14,9 +14,9 @@ void tearDown(void)
 {
 }
 
-static void check_personal_top_three(const int32_t *scores, size_t scores_len,
-                                     const int32_t *expected,
-                                     size_t expected_len)
+static void check_personal_top_three(const int32_t *expected,
+                                     size_t expected_len, const int32_t *scores,
+                                     size_t scores_len)
 {
    int32_t top_scores[TOP_SCORES_ARRAY_SIZE] = { 0 };
 
@@ -47,8 +47,8 @@ static void test_personal_top_three_from_a_list_of_scores(void)
    TEST_IGNORE();
    const int scores[] = { 10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70 };
    const int expected[] = { 100, 90, 70 };
-   check_personal_top_three(scores, ARRAY_SIZE(scores), expected,
-                            ARRAY_SIZE(expected));
+   check_personal_top_three(expected, ARRAY_SIZE(expected), scores,
+                            ARRAY_SIZE(scores));
 }
 
 static void test_personal_top_highest_to_lowest(void)
@@ -56,8 +56,8 @@ static void test_personal_top_highest_to_lowest(void)
    TEST_IGNORE();
    const int scores[] = { 20, 10, 30 };
    const int expected[] = { 30, 20, 10 };
-   check_personal_top_three(scores, ARRAY_SIZE(scores), expected,
-                            ARRAY_SIZE(expected));
+   check_personal_top_three(expected, ARRAY_SIZE(expected), scores,
+                            ARRAY_SIZE(scores));
 }
 
 static void test_personal_top_when_there_is_a_tie(void)
@@ -65,8 +65,8 @@ static void test_personal_top_when_there_is_a_tie(void)
    TEST_IGNORE();
    const int scores[] = { 40, 20, 40, 30 };
    const int expected[] = { 40, 40, 30 };
-   check_personal_top_three(scores, ARRAY_SIZE(scores), expected,
-                            ARRAY_SIZE(expected));
+   check_personal_top_three(expected, ARRAY_SIZE(expected), scores,
+                            ARRAY_SIZE(scores));
 }
 
 static void test_personal_top_when_there_are_less_than_3(void)
@@ -74,8 +74,8 @@ static void test_personal_top_when_there_are_less_than_3(void)
    TEST_IGNORE();
    const int scores[] = { 30, 70 };
    const int expected[] = { 70, 30 };
-   check_personal_top_three(scores, ARRAY_SIZE(scores), expected,
-                            ARRAY_SIZE(expected));
+   check_personal_top_three(expected, ARRAY_SIZE(expected), scores,
+                            ARRAY_SIZE(scores));
 }
 
 static void test_personal_top_when_there_is_only_one(void)
@@ -83,8 +83,8 @@ static void test_personal_top_when_there_is_only_one(void)
    TEST_IGNORE();
    const int scores[] = { 40 };
    const int expected[] = { 40 };
-   check_personal_top_three(scores, ARRAY_SIZE(scores), expected,
-                            ARRAY_SIZE(expected));
+   check_personal_top_three(expected, ARRAY_SIZE(expected), scores,
+                            ARRAY_SIZE(scores));
 }
 
 int main(void)


### PR DESCRIPTION
On #908  I noticed a small inconsistency nit in the ordering of parameters for the `check_personal-top_three()` function.
This change means that expected values arguments are always first in the parameter list for the function calls used within all `test_*` functions.