### PR TITLE
Hello World should start with the default stub

### DIFF
--- a/exercises/practice/hello-world/hello_world.c
+++ b/exercises/practice/hello-world/hello_world.c
@@ -1,14 +1,7 @@
-// Include the standard definitions header from the standard library, so that we
-// have access to 'NULL'. This can be removed if your changes remove the need
-// for 'NULL'.
-#include <stddef.h>
-
 #include "hello_world.h"
 
 // Define the function itself.
 const char *hello(void)
 {
-   // To fix this function, change the return statement here to instead return
-   // a string equivalent to the string expected by the failing test.
-   return NULL;
+   return "Goodbye, Mars!";
 }


### PR DESCRIPTION
@ErikSchierboom Could you please:
1. Check this is correct / get it over the line
2. Grep all other Hello Worlds and check that they all contain the word "Mars" and fix any that don't.

Thanks :)