### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/acronym/.approaches/look-for-start-chars/content.md
+++ b/exercises/practice/acronym/.approaches/look-for-start-chars/content.md
@@ -44,9 +44,9 @@ char *abbreviate(const char *phrase)
 
 This `abbreviate` function starts by checking for the input pointer being `NULL` or an empty string.
 
-```exercism/note
+~~~~exercism/note
 There is a difference between a `NULL` pointer and a valid pointer pointing to a null character (`'\0'`).
-```
+~~~~
 
 If the pointer is either `NULL` or en empty string, the function returns `NULL`.
 

--- a/exercises/practice/beer-song/.approaches/complexity-in-data/content.md
+++ b/exercises/practice/beer-song/.approaches/complexity-in-data/content.md
@@ -79,12 +79,12 @@ Accordingly, the `for` loop iterates from the `start_bottles` while the `bottle`
 
 Inside the `for` loop, the [snprintf][snprintf] function uses the `MAX_LINE_LENGTH` value to write each line to the buffer.
 
-```exercism/note
+~~~~exercism/note
 The `snprintf` function is used instead of `sprintf`, because the `sprintf` function can be dangerous,
 as it can potentially output more characters than can fit in the allocation size of the buffer.
 That is particularly a concern when writing user input to the buffer.
 This approach does not do that, but to use `snprintf` instead of `sprintf` is a good habit for secure coding.
-```
+~~~~
 
 A [ternary operator][ternary] is used to check if the `bottle` number is greater than `1`.
 If so, the element at index `2` of the `FIRST_LINE` array is used as a template,

--- a/exercises/practice/binary-search/.approaches/while-with-if-statements/content.md
+++ b/exercises/practice/binary-search/.approaches/while-with-if-statements/content.md
@@ -50,11 +50,11 @@ If so, then a pointer to that value is returned.
 
 If the first `if` statement does not return, then another `if` statement is used to check the element.
 
-```exercism/note
+~~~~exercism/note
 Note that if an `if` statement can return, it does not need to be followed by an `else if ` or an `else`.
 If the statement returns, then control flow will leave the function.
 If the statement does not return, control will fall through to the next statement anyway.
-```
+~~~~
 
 If the value at the middle index is less than the value being searched for, then `left` is set to the middle index
 plus one so that the next iteration will look for higher numbers.

--- a/exercises/practice/hamming/.approaches/increment-pointers/content.md
+++ b/exercises/practice/hamming/.approaches/increment-pointers/content.md
@@ -33,9 +33,9 @@ int compute(const char *lhs, const char *rhs)
 This approach starts by checking if either the `lhs` or `rhs` strings are `NULL`.
 If so, then the function returns `-1`.
 
-```exercism/note
+~~~~exercism/note
 There is a difference between a `NULL` pointer and a valid pointer pointing to a null character (`'\0'`).
-```
+~~~~
 
 The variable to keep track of the distance count is initialized to `0`.
 

--- a/exercises/practice/isogram/.approaches/bitfield/content.md
+++ b/exercises/practice/isogram/.approaches/bitfield/content.md
@@ -53,9 +53,9 @@ This approach uses the [ASCII][ascii] value of the letter to set the correspondi
 The approach starts by checking if the pointer to the input phrase is `NULL`.
 If so, then the function returns `false`.
 
-```exercism/note
+~~~~exercism/note
 There is a difference between a `NULL` pointer and a valid pointer pointing to a null character (`'\0'`).
-```
+~~~~
 
 The `uint32_t` value for the bit field is initialized with `0`.
 A character to subtract by is initialized to `'a'`.

--- a/exercises/practice/linked-list/.approaches/circular-doubly-linked-list/content.md
+++ b/exercises/practice/linked-list/.approaches/circular-doubly-linked-list/content.md
@@ -213,7 +213,7 @@ If the node being removed is either the `head` or the `tail`, then the `head` or
 
 The removed node's `prev` and `next` fields are set to `NULL`, the removed node's memory is freed, and the removed node is set to `NULL`.
 
-```exercism/note
+~~~~exercism/note
 Setting the freed pointer to `NULL` is a housekeeping habit to ensure that if the freed pointer is tested for `NULL` later in the function,
 it will properly be `NULL`.
 That test doesn't happen in the current code, but if the function were ever refactored it might be helpful to have that housekeeping done.
@@ -221,7 +221,7 @@ The pointer in the calling code which was passed into the `destroy_node` functio
 meaning that the address it points to is copied into the function.
 Setting the copy of the pointer address to `NULL` has no effect on the original pointer in the calling code.
 With its memory freed, the original pointer still retains its address, now pointing to deallocated memory, making it a [dangling pointer](https://www.geeksforgeeks.org/dangling-void-null-wild-pointers/).
-```
+~~~~
 
 ```c
 node->prev = NULL;

--- a/exercises/practice/pig-latin/.approaches/strchr-strstr-strtok/content.md
+++ b/exercises/practice/pig-latin/.approaches/strchr-strstr-strtok/content.md
@@ -108,10 +108,10 @@ to the `output` string.
 
 The [`strncat`][strncat] function is used to concatenate to the `output` to ensure we don't attempt to write past the end of the output string.
 
-```exercism/note
+~~~~exercism/note
 For a discussion of why `strcat` is used instead of `strncat` to append a string of known size (e.g. `"ay"`), see this
 [StackOverflow thread](https://stackoverflow.com/questions/53408543/strncat-wformat-overflow-warning-when-using-gcc-8-2-1).
-```
+~~~~
 
 If the `word` does not start with a vowel, then the [`strstr`][strstr] function is used to check if the `word` starts with `xr` or `yt`.
 
@@ -182,10 +182,10 @@ After the loop is done, if no vowel was found, then the suffix, which is now the
 
 The `translate` function takes a pointer to the `input` phrase.
 
-```exercism/note
+~~~~exercism/note
 For production, checks would be made that the pointer is not `NULL` and that allocated memory does not return a `NULL` pointer,
 but those and other checks are not made in this approach to keep the implementation simple.
-```
+~~~~
 
 The [`calloc`][calloc] function is used to allocate memory for the `output` string.
 

--- a/exercises/practice/queen-attack/.approaches/helper-functions/content.md
+++ b/exercises/practice/queen-attack/.approaches/helper-functions/content.md
@@ -74,10 +74,10 @@ does not equal `1 - 4 = -3` (the absolute of which is `3`.)
 
 The `can_attack` function uses a couple of chained [ternary operators][ternary] that use the helper functions to return the answer.
 
-```exercism/note
+~~~~exercism/note
 Some coders do not find chained ternary operators to be as readable as a series of `if`, `else/if`, and/or `else` statements,
 which could be used here instead.
-```
+~~~~
 
 If the first ternary expression determines the positions are not valid, then `INVALID_POSITION` is returned.
 Otherwise, the second ternary expression checks if the queens can attack each other.

--- a/exercises/practice/scrabble-score/.approaches/array-lookup/content.md
+++ b/exercises/practice/scrabble-score/.approaches/array-lookup/content.md
@@ -87,9 +87,9 @@ The `score` function takes a pointer to the `word` being scored.
 It checks if the pointer is `NULL`.
 If so, then the function returns `0`.
 
-```exercism/note
+~~~~exercism/note
 There is a difference between a `NULL` pointer and a valid pointer pointing to a null character (`'\0'`).
-```
+~~~~
 
 The `initialize_scores` function is called.
 If the `scores`  array has already been initialized, the function will return immediately.

--- a/exercises/practice/scrabble-score/.approaches/switch-statement/content.md
+++ b/exercises/practice/scrabble-score/.approaches/switch-statement/content.md
@@ -79,9 +79,9 @@ The `score` function takes a pointer to the `word` being scored.
 It checks if the pointer is `NULL`.
 If so, then the function returns `0`.
 
-```exercism/note
+~~~~exercism/note
 There is a difference between a `NULL` pointer and a valid pointer pointing to a null character (`'\0'`).
-```
+~~~~
 
 The variable to keep track of the accumulated score is initialized to `0`.
 

--- a/exercises/practice/sieve/.approaches/array-of-ones-and-zeros/content.md
+++ b/exercises/practice/sieve/.approaches/array-of-ones-and-zeros/content.md
@@ -47,11 +47,11 @@ uint32_t sieve(uint32_t limit, uint32_t *primes, size_t max_primes)
 This approach starts by defining the `MAX_LEN` of the array of composite values to be `1001`,
 given that the largest length for the result array expected by the tests is `1000`.
 
-```exercism/warning
+~~~~exercism/warning
 It would be tempting to set the length of the composite array as a [Variable-length array](https://en.wikipedia.org/wiki/Variable-length_array)
 dependent on the value of the `limit`, however, although VLAs were legal in C99, they were made optional in C11,
 so compilers that support C11 and later are not required to implement VLAs.
-```
+~~~~
 
 The `sieve` function starts by returning `0` if either the `limit` is too small to contain a prime,
 or if the number of primes expected back is `0`.


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705