### PR TITLE
Add used types to the pythagorean_triplet.h

### DIFF
--- a/exercises/practice/pythagorean-triplet/pythagorean_triplet.h
+++ b/exercises/practice/pythagorean-triplet/pythagorean_triplet.h
@@ -1,4 +1,21 @@
 #ifndef PYTHAGOREAN_TRIPLET_H
 #define PYTHAGOREAN_TRIPLET_H
 
+#include <stdint.h>
+
+typedef struct
+{
+  int a, b, c;
+} triplet_t;
+
+typedef struct
+{
+  int count;
+  triplet_t *triplets;
+} triplets_t;
+
+triplets_t *triplets_with_sum (uint16_t sum);
+
+void free_triplets (triplets_t *pt);
+
 #endif


### PR DESCRIPTION
It would be better to see all used in the exercise types in the header file, than recover them from the source.