### PR TITLE
Replace usage of UnityBegin/UnityEnd with UNITY_BEGIN/UNITY_END

### DIFF
--- a/bin/check-unitybegin
+++ b/bin/check-unitybegin
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-usage="check-unitybegin - checks UnityBegin() line for all exercises in a given directory
+usage="check-unitybegin - checks UNITY_BEGIN() line for all exercises in a given directory
 Usage:
   check-unitybegin <path-to-exercises>
 
@@ -20,8 +20,8 @@ check_exercises () {
     for f in "${1}"/*/test_*; do
         if [ -f "${f}" ]
         then
-            if ! grep -q UnityBegin\(\""$(basename "$f")"\"\) "$f"; then
-                echo "$f needs correct UnityBegin line"
+            if ! grep -q UNITY_BEGIN\(\) "$f"; then
+                echo "$f needs correct UNITY_BEGIN line"
                 (( ERROR_COUNT++ ))
             fi
         else

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,7 +138,6 @@ If you would like the [`/format`][format-workflow] automated action to work corr
 * `checks.yml` runs `shellcheck` on the tool scripts and subsequently runs the following of those tools:
   * `./bin/check-unitybegin`
   * `./bin/verify-unity-version`
-  * `./bin/check-unitybegin`
   * `./bin/check-include-guards`
   * [Lychee link checker][lychee] action
 * `configlet.yml` fetches the latest version of configlet from which it then runs the `lint` command on the track
@@ -150,10 +149,9 @@ If you would like the [`/format`][format-workflow] automated action to work corr
 You can see from the [workflows][] that GitHub is instructed to run tools from the [`./bin`][bin] directory.
 The work the tools in this directory perform is described as follows:
 
-* `check-unitybegin` ensures that every test file correctly adds the `UnityBegin("{test-file-name}")` line at the start of its `main()` function.
+* `check-unitybegin` ensures that every test file correctly adds the `UNITY_BEGIN()` line at the start of its `main()` function.
 * `fetch-configlet` fetches the `configlet` tool from its [repository][configlet].
 * `verify-unity-version` checks the version of the Unity test framework used by every exercise. The version this file should check for is specified in [`./docs/VERSIONS.md`][versions]
-* `check-unitybegin` ensures that every test file correctly adds the `UnityBegin("{test-file-name}")` line at the start of its `main()` function.
 * `check-include-guards` checks that the include guards used in each exercises stub and example header are using the correct format, as follows:
 
     ```c

--- a/docs/C_STYLE_GUIDE.md
+++ b/docs/C_STYLE_GUIDE.md
@@ -148,19 +148,18 @@ static void test_the_third(void)
 
 Last in the file is the `main()` function.
 The function body of main follows a particular layout itself.
-First a call to `UnityBegin()` followed by an empty line, then the tests.
-The last test is followed by another empty line and then a call to `UnityEnd()`, before returning.
+First a call to `UNITY_BEGIN()` followed by an empty line, then the tests.
+The last test is followed by another empty line before returning the result of `UNITY_END()`.
 
 ```c
 int main(void)
 {
-    UnityBegin("test/test_file_name.c");
+    UNITY_BEGIN();
 
     RUN_TEST(test_foo);
     RUN_TEST(test_bar);
 
-    UnityEnd();
-    return 0;
+    return UNITY_END();
 }
 ```
 

--- a/exercises/practice/acronym/test_acronym.c
+++ b/exercises/practice/acronym/test_acronym.c
@@ -112,7 +112,7 @@ static void test_underscore_emphasis(void)
 
 int main(void)
 {
-   UnityBegin("test_acronym.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_null_string);
    RUN_TEST(test_empty_string);
@@ -126,5 +126,5 @@ int main(void)
    RUN_TEST(test_apostrophes);
    RUN_TEST(test_underscore_emphasis);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/all-your-base/test_all_your_base.c
+++ b/exercises/practice/all-your-base/test_all_your_base.c
@@ -207,7 +207,7 @@ static void test_both_bases_are_negative(void)
 
 int main(void)
 {
-   UnityBegin("test_all_your_base.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_single_bit_to_decimal);
    RUN_TEST(test_binary_to_single_decimal);
@@ -231,5 +231,5 @@ int main(void)
    RUN_TEST(test_output_base_is_negative);
    RUN_TEST(test_both_bases_are_negative);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/allergies/test_allergies.c
+++ b/exercises/practice/allergies/test_allergies.c
@@ -398,7 +398,7 @@ static void test_no_allergen_score_parts_without_highest_valid_score(void)
 
 int main(void)
 {
-   UnityBegin("test_allergies.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_not_allergic_to_anything_for_eggs);
    RUN_TEST(test_allergic_only_to_eggs);
@@ -459,5 +459,5 @@ int main(void)
    RUN_TEST(test_no_allergen_score_parts);
    RUN_TEST(test_no_allergen_score_parts_without_highest_valid_score);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/anagram/test_anagram.c
+++ b/exercises/practice/anagram/test_anagram.c
@@ -273,7 +273,7 @@ static void test_words_other_than_themselves_can_be_anagrams(void)
 
 int main(void)
 {
-   UnityBegin("test_anagram.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_no_matches);
    RUN_TEST(test_detect_two_anagrams);
@@ -294,5 +294,5 @@ int main(void)
        test_words_are_not_anagrams_of_themselves_even_if_letter_case_is_completely_different);
    RUN_TEST(test_words_other_than_themselves_can_be_anagrams);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/armstrong-numbers/test_armstrong_numbers.c
+++ b/exercises/practice/armstrong-numbers/test_armstrong_numbers.c
@@ -64,7 +64,7 @@ static void test_seven_digit_number_that_is_not_an_armstrong_number(void)
 
 int main(void)
 {
-   UnityBegin("test_armstrong_numbers.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_zero_is_an_armstrong_number);
    RUN_TEST(test_single_digit_numbers_are_armstrong_numbers);
@@ -76,5 +76,5 @@ int main(void)
    RUN_TEST(test_seven_digit_number_that_is_an_armstrong_number);
    RUN_TEST(test_seven_digit_number_that_is_not_an_armstrong_number);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/atbash-cipher/test_atbash_cipher.c
+++ b/exercises/practice/atbash-cipher/test_atbash_cipher.c
@@ -118,7 +118,7 @@ static void test_decode_with_no_spaces(void)
 
 int main(void)
 {
-   UnityBegin("test_atbash_cipher.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_encode_yes);
    RUN_TEST(test_encode_no);
@@ -136,5 +136,5 @@ int main(void)
    RUN_TEST(test_decode_with_too_many_spaces);
    RUN_TEST(test_decode_with_no_spaces);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/beer-song/test_beer_song.c
+++ b/exercises/practice/beer-song/test_beer_song.c
@@ -464,7 +464,7 @@ static void test_all_verses(void)
 
 int main(void)
 {
-   UnityBegin("test_beer_song.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_first_generic_verse);
    RUN_TEST(test_last_generic_verse);
@@ -475,5 +475,5 @@ int main(void)
    RUN_TEST(test_last_three_verses);
    RUN_TEST(test_all_verses);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/binary-search-tree/test_binary_search_tree.c
+++ b/exercises/practice/binary-search-tree/test_binary_search_tree.c
@@ -192,7 +192,7 @@ static void test_sorted_data_can_sort_complex_tree(void)
 
 int main(void)
 {
-   UnityBegin("test_binary_search_tree.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_data_data_is_retained);
    RUN_TEST(test_data_smaller_number_at_left_node);
@@ -205,5 +205,5 @@ int main(void)
    RUN_TEST(test_sorted_data_can_sort_if_second_number_is_greater_than_first);
    RUN_TEST(test_sorted_data_can_sort_complex_tree);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/binary-search/test_binary_search.c
+++ b/exercises/practice/binary-search/test_binary_search.c
@@ -99,7 +99,7 @@ static void test_nothing_is_found_when_the_left_and_right_bounds_cross(void)
 
 int main(void)
 {
-   UnityBegin("test_binary_search.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_finds_a_value_in_an_array_with_one_element);
    RUN_TEST(test_a_value_in_the_middle_of_an_array);
@@ -113,5 +113,5 @@ int main(void)
    RUN_TEST(test_nothing_is_found_in_an_empty_array);
    RUN_TEST(test_nothing_is_found_when_the_left_and_right_bounds_cross);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/binary/test_binary.c
+++ b/exercises/practice/binary/test_binary.c
@@ -100,7 +100,7 @@ static void test_a_number_and_a_word_whitespace_separated_is_invalid(void)
 
 int main(void)
 {
-   UnityBegin("test_binary.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_binary_0_is_decimal_0);
    RUN_TEST(test_binary_1_is_decimal_1);
@@ -118,5 +118,5 @@ int main(void)
    RUN_TEST(test_a_number_with_internal_non_binary_characters_is_invalid);
    RUN_TEST(test_a_number_and_a_word_whitespace_separated_is_invalid);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/bob/test_bob.c
+++ b/exercises/practice/bob/test_bob.c
@@ -173,7 +173,7 @@ static void test_non_question_ending_with_whitespace(void)
 
 int main(void)
 {
-   UnityBegin("test_bob.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_stating_something);
    RUN_TEST(test_shouting);
@@ -201,5 +201,5 @@ int main(void)
    RUN_TEST(test_other_whitespace);
    RUN_TEST(test_non_question_ending_with_whitespace);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/circular-buffer/test_circular_buffer.c
+++ b/exercises/practice/circular-buffer/test_circular_buffer.c
@@ -261,7 +261,7 @@ static void test_initial_clear_does_not_affect_wrapping(void)
 
 int main(void)
 {
-   UnityBegin("test_circular_buffer.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_reading_empty_buffer_fails);
    RUN_TEST(test_can_read_item_just_written);
@@ -278,5 +278,5 @@ int main(void)
    RUN_TEST(test_overwrite_replaces_oldest_item_remaining_following_read);
    RUN_TEST(test_initial_clear_does_not_affect_wrapping);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/clock/test_clock.c
+++ b/exercises/practice/clock/test_clock.c
@@ -537,7 +537,7 @@ static void test_compare_full_clock_and_zeroed_clock(void)
 
 int main(void)
 {
-   UnityBegin("test_clock.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_on_the_hour);
    RUN_TEST(test_past_the_hour);
@@ -592,5 +592,5 @@ int main(void)
    RUN_TEST(test_compare_clocks_with_negative_hours_and_minute_that_wrap);
    RUN_TEST(test_compare_full_clock_and_zeroed_clock);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/collatz-conjecture/test_collatz_conjecture.c
+++ b/exercises/practice/collatz-conjecture/test_collatz_conjecture.c
@@ -41,7 +41,7 @@ static void test_negative_value_is_an_error(void)
 
 int main(void)
 {
-   UnityBegin("test_collatz_conjecture.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_zero_steps_for_one);
    RUN_TEST(test_divide_if_even);
@@ -50,5 +50,5 @@ int main(void)
    RUN_TEST(test_zero_is_an_error);
    RUN_TEST(test_negative_value_is_an_error);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/complex-numbers/test_complex_numbers.c
+++ b/exercises/practice/complex-numbers/test_complex_numbers.c
@@ -490,7 +490,7 @@ static void test_divide_real_number_by_complex_number(void)
 
 int main(void)
 {
-   UnityBegin("test_complex_numbers.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_real_part_of_a_purely_real_number);
    RUN_TEST(test_real_part_of_a_purely_imaginary_number);
@@ -544,5 +544,5 @@ int main(void)
    RUN_TEST(test_divide_complex_number_by_real_number);
    RUN_TEST(test_divide_real_number_by_complex_number);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/crypto-square/test_crypto_square.c
+++ b/exercises/practice/crypto-square/test_crypto_square.c
@@ -85,7 +85,7 @@ test_54_char_plaintext_gives_7_chunks_last_two_with_trailing_spaces(void)
 
 int main(void)
 {
-   UnityBegin("test_crypto_square.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_empty_text_res_in_an_empty_ciphertext);
    RUN_TEST(test_lowercase);
@@ -96,5 +96,5 @@ int main(void)
    RUN_TEST(
        test_54_char_plaintext_gives_7_chunks_last_two_with_trailing_spaces);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/darts/test_darts.c
+++ b/exercises/practice/darts/test_darts.c
@@ -127,7 +127,7 @@ static void test_asymmetric_position_between_the_inner_and_middle_circles(void)
 
 int main(void)
 {
-   UnityBegin("test_darts.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_missed_target);
    RUN_TEST(test_on_the_outer_circle);
@@ -143,5 +143,5 @@ int main(void)
    RUN_TEST(test_just_outside_the_outer_circle);
    RUN_TEST(test_asymmetric_position_between_the_inner_and_middle_circles);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/diamond/test_diamond.c
+++ b/exercises/practice/diamond/test_diamond.c
@@ -144,7 +144,7 @@ static void test_rows_largest_possible_diamond(void)
 
 int main(void)
 {
-   UnityBegin("test_diamond.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_rows_degenerate_case_with_a_single_a_row);
    RUN_TEST(
@@ -155,5 +155,5 @@ int main(void)
        test_rows_smallest_non_degenerate_case_with_even_diamond_side_length);
    RUN_TEST(test_rows_largest_possible_diamond);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/difference-of-squares/test_difference_of_squares.c
+++ b/exercises/practice/difference-of-squares/test_difference_of_squares.c
@@ -64,7 +64,7 @@ static void test_difference_of_squares_100(void)
 
 int main(void)
 {
-   UnityBegin("test_difference_of_squares.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_square_of_sum_1);
    RUN_TEST(test_square_of_sum_5);
@@ -76,5 +76,5 @@ int main(void)
    RUN_TEST(test_difference_of_squares_5);
    RUN_TEST(test_difference_of_squares_100);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/etl/test_etl.c
+++ b/exercises/practice/etl/test_etl.c
@@ -105,12 +105,12 @@ static void test_multiple_scores_with_differing_numbers_of_letters(void)
 
 int main(void)
 {
-   UnityBegin("test_etl.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_a_single_letter);
    RUN_TEST(test_single_score_with_multiple_letters);
    RUN_TEST(test_multiple_scores_with_multiple_letters);
    RUN_TEST(test_multiple_scores_with_differing_numbers_of_letters);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/gigasecond/test_gigasecond.c
+++ b/exercises/practice/gigasecond/test_gigasecond.c
@@ -105,7 +105,7 @@ static void test_your_birthday(void)
 
 int main(void)
 {
-   UnityBegin("test_gigasecond.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_date);
    RUN_TEST(test_another_date);
@@ -114,5 +114,5 @@ int main(void)
    RUN_TEST(test_date_and_time_with_day_rollover);
    // RUN_TEST(test_your_birthday);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/grade-school/test_grade_school.c
+++ b/exercises/practice/grade-school/test_grade_school.c
@@ -339,7 +339,7 @@ static void test_students_are_sorted_by_name_in_grade(void)
 
 int main(void)
 {
-   UnityBegin("test_grade_school.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_roster_is_empty_when_no_student_added);
    RUN_TEST(test_add_student);
@@ -362,5 +362,5 @@ int main(void)
    RUN_TEST(test_student_not_added_to_other_grade_for_multiple_grades);
    RUN_TEST(test_students_are_sorted_by_name_in_grade);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/grains/test_grains.c
+++ b/exercises/practice/grains/test_grains.c
@@ -70,7 +70,7 @@ static void test_total(void)
 
 int main(void)
 {
-   UnityBegin("test_grains.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_square_1);
    RUN_TEST(test_square_2);
@@ -83,5 +83,5 @@ int main(void)
    RUN_TEST(test_square_greater_than_64_does_not_exist);
    RUN_TEST(test_total);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/hamming/test_hamming.c
+++ b/exercises/practice/hamming/test_hamming.c
@@ -64,7 +64,7 @@ static void test_disallow_empty_second_strand(void)
 
 int main(void)
 {
-   UnityBegin("test_hamming.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_empty_strands);
    RUN_TEST(test_single_identical_strands);
@@ -76,5 +76,5 @@ int main(void)
    RUN_TEST(test_disallow_empty_first_strand);
    RUN_TEST(test_disallow_empty_second_strand);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/hello-world/test_hello_world.c
+++ b/exercises/practice/hello-world/test_hello_world.c
@@ -27,9 +27,9 @@ static void test_say_hi(void)
 // Runs the test(s)
 int main(void)
 {
-   UnityBegin("test_hello_world.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_say_hi);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/high-scores/test_high_scores.c
+++ b/exercises/practice/high-scores/test_high_scores.c
@@ -89,7 +89,7 @@ static void test_personal_top_when_there_is_only_one(void)
 
 int main(void)
 {
-   UnityBegin("test_high_scores.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_latest_score);
    RUN_TEST(test_personal_best);
@@ -99,5 +99,5 @@ int main(void)
    RUN_TEST(test_personal_top_when_there_are_less_than_3);
    RUN_TEST(test_personal_top_when_there_is_only_one);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/isogram/test_isogram.c
+++ b/exercises/practice/isogram/test_isogram.c
@@ -102,7 +102,7 @@ static void test_word_with_duplicated_character_and_with_two_hyphens(void)
 
 int main(void)
 {
-   UnityBegin("test_isogram.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_empty_string);
    RUN_TEST(test_null);
@@ -120,5 +120,5 @@ int main(void)
    RUN_TEST(test_same_first_and_last_characters);
    RUN_TEST(test_word_with_duplicated_character_and_with_two_hyphens);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/kindergarten-garden/test_kindergarten_garden.c
+++ b/exercises/practice/kindergarten-garden/test_kindergarten_garden.c
@@ -176,7 +176,7 @@ static void test_full_garden_for_larry_last_student_s_garden(void)
 
 int main(void)
 {
-   UnityBegin("test_kindergarten_garden.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_partial_garden_garden_with_single_student);
    RUN_TEST(test_partial_garden_different_garden_with_single_student);
@@ -196,5 +196,5 @@ int main(void)
    RUN_TEST(test_full_garden_for_kincaid_second_to_last_student_s_garden);
    RUN_TEST(test_full_garden_for_larry_last_student_s_garden);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/largest-series-product/test_largest_series_product.c
+++ b/exercises/practice/largest-series-product/test_largest_series_product.c
@@ -90,7 +90,7 @@ static void test_rejects_negative_span(void)
 
 int main(void)
 {
-   UnityBegin("test_largest_series_product.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_finds_the_largest_product_if_span_equals_length);
    RUN_TEST(test_can_find_the_largest_product_of_2_with_numbers_in_order);
@@ -106,5 +106,5 @@ int main(void)
    RUN_TEST(test_rejects_invalid_character_in_digits);
    RUN_TEST(test_rejects_negative_span);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/leap/test_leap.c
+++ b/exercises/practice/leap/test_leap.c
@@ -65,7 +65,7 @@ static void test_year_divisible_by_200_not_divisible_by_400_in_common_year(void)
 
 int main(void)
 {
-   UnityBegin("test_leap.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_year_not_divisible_by_4_in_common_year);
    RUN_TEST(test_year_divisible_by_2_not_divisible_by_4_in_common_year);
@@ -77,5 +77,5 @@ int main(void)
    RUN_TEST(test_year_divisible_by_400_but_not_by_125_is_still_a_leap_year);
    RUN_TEST(test_year_divisible_by_200_not_divisible_by_400_in_common_year);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/linked-list/test_linked_list.c
+++ b/exercises/practice/linked-list/test_linked_list.c
@@ -217,7 +217,7 @@ static void test_deletes_only_the_first_occurrence(void)
 
 int main(void)
 {
-   UnityBegin("test_linked_list.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_pop_gets_element_from_the_list);
    RUN_TEST(test_push_pop_respectively_add_remove_at_the_end_of_the_list);
@@ -241,5 +241,5 @@ int main(void)
    RUN_TEST(test_delete_does_not_modify_the_list_if_the_element_is_not_found);
    RUN_TEST(test_deletes_only_the_first_occurrence);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/list-ops/test_list_ops.c
+++ b/exercises/practice/list-ops/test_list_ops.c
@@ -369,7 +369,7 @@ static void test_reverse_non_empty_list(void)
 
 int main(void)
 {
-   UnityBegin("test_list_ops.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_append_empty_lists);
    RUN_TEST(test_append_list_to_empty_list);
@@ -392,5 +392,5 @@ int main(void)
    RUN_TEST(test_reverse_empty_list);
    RUN_TEST(test_reverse_non_empty_list);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/luhn/test_luhn.c
+++ b/exercises/practice/luhn/test_luhn.c
@@ -145,7 +145,7 @@ test_non_numeric_non_space_char_in_middle_with_sum_divisible_by_10_isnt_allowed(
 
 int main(void)
 {
-   UnityBegin("test_luhn.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_single_digit_strings_can_not_be_valid);
    RUN_TEST(test_a_single_zero_is_invalid);
@@ -172,5 +172,5 @@ int main(void)
    RUN_TEST(
        test_non_numeric_non_space_char_in_middle_with_sum_divisible_by_10_isnt_allowed);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/matching-brackets/test_matching_brackets.c
+++ b/exercises/practice/matching-brackets/test_matching_brackets.c
@@ -153,7 +153,7 @@ static void test_complex_latex_expression(void)
 
 int main(void)
 {
-   UnityBegin("test_matching_brackets.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_paired_square_brackets);
    RUN_TEST(test_empty_string);
@@ -176,5 +176,5 @@ int main(void)
    RUN_TEST(test_math_expression);
    RUN_TEST(test_complex_latex_expression);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/meetup/test_meetup.c
+++ b/exercises/practice/meetup/test_meetup.c
@@ -604,7 +604,7 @@ static void test_first_Friday_of_December_2012(void)
 
 int main(void)
 {
-   UnityBegin("test_meetup.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_monteenth_of_May_2013);
    RUN_TEST(test_monteenth_of_August_2013);
@@ -702,5 +702,5 @@ int main(void)
    RUN_TEST(test_last_Sunday_of_February_2015);
    RUN_TEST(test_first_Friday_of_December_2012);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/minesweeper/test_minesweeper.c
+++ b/exercises/practice/minesweeper/test_minesweeper.c
@@ -273,7 +273,7 @@ static void test_annotate_large_minefield(void)
 
 int main(void)
 {
-   UnityBegin("test_minesweeper.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_annotate_no_rows);
    RUN_TEST(test_annotate_no_columns);
@@ -288,5 +288,5 @@ int main(void)
    RUN_TEST(test_annotate_cross);
    RUN_TEST(test_annotate_large_minefield);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/nth-prime/test_nth_prime.c
+++ b/exercises/practice/nth-prime/test_nth_prime.c
@@ -40,7 +40,7 @@ static void test_there_is_no_zeroth_prime(void)
 
 int main(void)
 {
-   UnityBegin("test_nth_prime.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_first_prime);
    RUN_TEST(test_second_prime);
@@ -48,5 +48,5 @@ int main(void)
    RUN_TEST(test_big_prime);
    RUN_TEST(test_there_is_no_zeroth_prime);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/nucleotide-count/test_nucleotide_count.c
+++ b/exercises/practice/nucleotide-count/test_nucleotide_count.c
@@ -67,7 +67,7 @@ static void test_invalid_nucleotide(void)
 
 int main(void)
 {
-   UnityBegin("test_nucleotide_count.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_empty_strand);
    RUN_TEST(test_can_count_one_nucleotide_in_single_character_input);
@@ -75,5 +75,5 @@ int main(void)
    RUN_TEST(test_multiple_nucleotides);
    RUN_TEST(test_invalid_nucleotide);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/palindrome-products/test_palindrome_products.c
+++ b/exercises/practice/palindrome-products/test_palindrome_products.c
@@ -229,7 +229,7 @@ static void test_error_result_for_largest_if_min_is_more_than_max(void)
 
 int main(void)
 {
-   UnityBegin("test_palindrome_products.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_smallest_palindrome_from_single_digit_factors);
    RUN_TEST(test_largest_palindrome_from_single_digit_factors);
@@ -249,5 +249,5 @@ int main(void)
    RUN_TEST(test_error_result_for_smallest_if_min_is_more_than_max);
    RUN_TEST(test_error_result_for_largest_if_min_is_more_than_max);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/pangram/test_pangram.c
+++ b/exercises/practice/pangram/test_pangram.c
@@ -98,7 +98,7 @@ test_a_to_m_and_A_to_M_are_26_different_characters_but_not_pangram(void)
 
 int main(void)
 {
-   UnityBegin("test_pangram.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_null);
    RUN_TEST(test_empty_sentence);
@@ -112,5 +112,5 @@ int main(void)
    RUN_TEST(test_mixed_case_and_punctuation);
    RUN_TEST(test_a_to_m_and_A_to_M_are_26_different_characters_but_not_pangram);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/pascals-triangle/test_pascals_triangle.c
+++ b/exercises/practice/pascals-triangle/test_pascals_triangle.c
@@ -169,7 +169,7 @@ static void test_ten_rows(void)
 
 int main(void)
 {
-   UnityBegin("test_pascals_triangle.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_no_rows);
    RUN_TEST(test_single_row);
@@ -180,5 +180,5 @@ int main(void)
    RUN_TEST(test_six_rows);
    RUN_TEST(test_ten_rows);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/perfect-numbers/test_perfect_numbers.c
+++ b/exercises/practice/perfect-numbers/test_perfect_numbers.c
@@ -89,7 +89,7 @@ static void test_negative_integer_is_rejected(void)
 
 int main(void)
 {
-   UnityBegin("test_perfect_numbers.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_smallest_perfect_number_is_classified_correctly);
    RUN_TEST(test_medium_perfect_number_is_classified_correctly);
@@ -105,5 +105,5 @@ int main(void)
    RUN_TEST(test_zero_is_rejected);
    RUN_TEST(test_negative_integer_is_rejected);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/phone-number/test_phone_number.c
+++ b/exercises/practice/phone-number/test_phone_number.c
@@ -218,7 +218,7 @@ test_invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number(void)
 
 int main(void)
 {
-   UnityBegin("test_phone_number.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_cleans_the_number);
    RUN_TEST(test_cleans_numbers_with_dots);
@@ -242,5 +242,5 @@ int main(void)
    RUN_TEST(
        test_invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/pig-latin/test_pig_latin.c
+++ b/exercises/practice/pig-latin/test_pig_latin.c
@@ -154,7 +154,7 @@ static void test_a_whole_phrase(void)
 
 int main(void)
 {
-   UnityBegin("test_pig_latin.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_word_beginning_with_a);
    RUN_TEST(test_word_beginning_with_e);
@@ -179,5 +179,5 @@ int main(void)
    RUN_TEST(test_y_as_second_letter_in_two_letter_word);
    RUN_TEST(test_a_whole_phrase);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/pop-count/test_pop_count.c
+++ b/exercises/practice/pop-count/test_pop_count.c
@@ -38,12 +38,12 @@ static void test_13_eggs(void)
 
 int main(void)
 {
-   UnityBegin("test_pop_count.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_0_eggs);
    RUN_TEST(test_1_eggs);
    RUN_TEST(test_4_eggs);
    RUN_TEST(test_13_eggs);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/prime-factors/test_prime_factors.c
+++ b/exercises/practice/prime-factors/test_prime_factors.c
@@ -131,7 +131,7 @@ static void test_factors_include_a_large_prime(void)
 
 int main(void)
 {
-   UnityBegin("test_prime_factors.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_no_factors);
    RUN_TEST(test_prime_number);
@@ -146,5 +146,5 @@ int main(void)
    RUN_TEST(test_product_of_primes);
    RUN_TEST(test_factors_include_a_large_prime);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/pythagorean-triplet/test_pythagorean_triplet.c
+++ b/exercises/practice/pythagorean-triplet/test_pythagorean_triplet.c
@@ -131,7 +131,7 @@ static void test_triplets_for_large_number(void)
 
 int main(void)
 {
-   UnityBegin("test_pythagorean_triplet.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_triplets_whose_sum_is_12);
    RUN_TEST(test_triplets_whose_sum_is_108);
@@ -141,5 +141,5 @@ int main(void)
    RUN_TEST(test_several_matching_triplets);
    RUN_TEST(test_triplets_for_large_number);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/queen-attack/test_queen_attack.c
+++ b/exercises/practice/queen-attack/test_queen_attack.c
@@ -194,7 +194,7 @@ test_cannot_attack_if_falling_diagonals_only_same_when_reflected_across_longest_
 
 int main(void)
 {
-   UnityBegin("test_queen_attack.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_invalid_if_on_same_position);
    RUN_TEST(test_white_queen_must_have_row_on_board);
@@ -211,5 +211,5 @@ int main(void)
    RUN_TEST(
        test_cannot_attack_if_falling_diagonals_only_same_when_reflected_across_longest_falling_diagonal);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/rail-fence-cipher/test_rail_fence_cipher.c
+++ b/exercises/practice/rail-fence-cipher/test_rail_fence_cipher.c
@@ -62,7 +62,7 @@ static void test_decode_with_six_rails(void)
 
 int main(void)
 {
-   UnityBegin("test_rail_fence_cipher.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_encode_with_two_rails);
    RUN_TEST(test_encode_with_three_rails);
@@ -71,5 +71,5 @@ int main(void)
    RUN_TEST(test_decode_with_five_rails);
    RUN_TEST(test_decode_with_six_rails);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/raindrops/test_raindrops.c
+++ b/exercises/practice/raindrops/test_raindrops.c
@@ -125,7 +125,7 @@ static void test_the_sound_for_3125_is_plang_as_it_has_a_factor_5(void)
 
 int main(void)
 {
-   UnityBegin("test_raindrops.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_the_sound_for_1_is_1);
    RUN_TEST(test_the_sound_for_3_is_pling);
@@ -147,5 +147,5 @@ int main(void)
        test_the_sound_for_105_is_plangplangplong_as_it_has_factor_3_5_and_7);
    RUN_TEST(test_the_sound_for_3125_is_plang_as_it_has_a_factor_5);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/rational-numbers/test_rational_numbers.c
+++ b/exercises/practice/rational-numbers/test_rational_numbers.c
@@ -444,7 +444,7 @@ static void test_reduce_one_to_lowest_terms(void)
 
 int main(void)
 {
-   UnityBegin("test_rational_numbers.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_add_two_positive_rational_numbers);
    RUN_TEST(test_add_positive_and_negative_rational_numbers);
@@ -493,5 +493,5 @@ int main(void)
    RUN_TEST(test_reduce_integer_to_lowest_terms);
    RUN_TEST(test_reduce_one_to_lowest_terms);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/react/test_react.c
+++ b/exercises/practice/react/test_react.c
@@ -326,7 +326,7 @@ test_callbacks_not_called_if_dependencies_change_but_output_value_doesnt_change(
 
 int main(void)
 {
-   UnityBegin("test_react.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_input_cells_have_value);
    RUN_TEST(test_input_cells_value_can_be_set);
@@ -346,5 +346,5 @@ int main(void)
    RUN_TEST(
        test_callbacks_not_called_if_dependencies_change_but_output_value_doesnt_change);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/resistor-color-duo/test_resistor_color_duo.c
+++ b/exercises/practice/resistor-color-duo/test_resistor_color_duo.c
@@ -59,7 +59,7 @@ static void test_black_and_brown_one_digit(void)
 
 int main(void)
 {
-   UnityBegin("test_resistor_color_duo.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_brown_and_black);
    RUN_TEST(test_blue_and_grey);
@@ -69,5 +69,5 @@ int main(void)
    RUN_TEST(test_ignore_additional_colors);
    RUN_TEST(test_black_and_brown_one_digit);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/resistor-color-trio/test_resistor_color_trio.c
+++ b/exercises/practice/resistor-color-trio/test_resistor_color_trio.c
@@ -99,7 +99,7 @@ static void test_ignore_extra_colors(void)
 
 int main(void)
 {
-   UnityBegin("test_resistor_color_trio.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_orange_orange_black);
    RUN_TEST(test_blue_grey_brown);
@@ -112,5 +112,5 @@ int main(void)
    RUN_TEST(test_invalid_octal);
    RUN_TEST(test_ignore_extra_colors);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/resistor-color/test_resistor_color.c
+++ b/exercises/practice/resistor-color/test_resistor_color.c
@@ -39,12 +39,12 @@ static void test_colors(void)
 
 int main(void)
 {
-   UnityBegin("test_resistor_color.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_black);
    RUN_TEST(test_white);
    RUN_TEST(test_orange);
    RUN_TEST(test_colors);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/reverse-string/test_reverse_string.c
+++ b/exercises/practice/reverse-string/test_reverse_string.c
@@ -52,7 +52,7 @@ static void test_an_even_sized_word(void)
 
 int main(void)
 {
-   UnityBegin("test_reverse_string.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_an_empty_string);
    RUN_TEST(test_a_word);
@@ -61,5 +61,5 @@ int main(void)
    RUN_TEST(test_a_palindrome);
    RUN_TEST(test_an_even_sized_word);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/rna-transcription/test_rna_transcription.c
+++ b/exercises/practice/rna-transcription/test_rna_transcription.c
@@ -54,7 +54,7 @@ static void test_rna_complement(void)
 
 int main(void)
 {
-   UnityBegin("test_rna_transcription.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_empty_rna_sequence);
    RUN_TEST(test_rna_complement_of_cytosine_is_guanine);
@@ -63,5 +63,5 @@ int main(void)
    RUN_TEST(test_rna_complement_of_adenine_is_uracil);
    RUN_TEST(test_rna_complement);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/robot-simulator/test_robot_simulator.c
+++ b/exercises/practice/robot-simulator/test_robot_simulator.c
@@ -214,7 +214,7 @@ static void test_follow_series_of_instructions_moving_east_and_north(void)
 
 int main(void)
 {
-   UnityBegin("test_robot_simulator.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_create_at_origin_facing_north);
    RUN_TEST(test_create_at_negative_position_facing_south);
@@ -236,5 +236,5 @@ int main(void)
    RUN_TEST(test_follow_series_of_instructions_moving_west_and_south);
    RUN_TEST(test_follow_series_of_instructions_moving_east_and_north);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -178,7 +178,7 @@ static void test_3999_is_MMMCMXCIX(void)
 
 int main(void)
 {
-   UnityBegin("test_roman_numerals.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_1_is_I);
    RUN_TEST(test_2_is_II);
@@ -207,5 +207,5 @@ int main(void)
    RUN_TEST(test_3001_is_MMMI);
    RUN_TEST(test_3999_is_MMMCMXCIX);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/run-length-encoding/test_run_length_encoding.c
+++ b/exercises/practice/run-length-encoding/test_run_length_encoding.c
@@ -119,7 +119,7 @@ test_consistency_encode_followed_by_decode_gives_original_string(void)
 
 int main(void)
 {
-   UnityBegin("test_run_length_encoding.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_encode_empty_string);
    RUN_TEST(test_encode_single_characters_only_are_encoded_without_count);
@@ -135,5 +135,5 @@ int main(void)
    RUN_TEST(test_decode_lower_case_string);
    RUN_TEST(test_consistency_encode_followed_by_decode_gives_original_string);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/saddle-points/test_saddle_points.c
+++ b/exercises/practice/saddle-points/test_saddle_points.c
@@ -149,7 +149,7 @@ test_saddle_points_in_single_row_matrix_are_those_with_the_maximum_value(void)
 
 int main(void)
 {
-   UnityBegin("test_saddle_points.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_single_saddle_point);
    RUN_TEST(test_empty_matrix_has_no_saddle_points);
@@ -163,5 +163,5 @@ int main(void)
    RUN_TEST(
        test_saddle_points_in_single_row_matrix_are_those_with_the_maximum_value);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/say/test_say.c
+++ b/exercises/practice/say/test_say.c
@@ -171,7 +171,7 @@ static void test_numbers_above_999_999_999_999_are_out_of_range(void)
 
 int main(void)
 {
-   UnityBegin("test_say.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_zero);
    RUN_TEST(test_one);
@@ -193,5 +193,5 @@ int main(void)
    RUN_TEST(test_numbers_below_zero_are_out_of_range);
    RUN_TEST(test_numbers_above_999_999_999_999_are_out_of_range);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/scrabble-score/test_scrabble_score.c
+++ b/exercises/practice/scrabble-score/test_scrabble_score.c
@@ -76,7 +76,7 @@ static void test_entire_alphabet_available(void)
 
 int main(void)
 {
-   UnityBegin("test_scrabble_score.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_lowercase_letter);
    RUN_TEST(test_uppercase_letter);
@@ -90,5 +90,5 @@ int main(void)
    RUN_TEST(test_empty_input);
    RUN_TEST(test_entire_alphabet_available);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/secret-handshake/test_secret_handshake.c
+++ b/exercises/practice/secret-handshake/test_secret_handshake.c
@@ -114,7 +114,7 @@ static void test_commands_do_nothing_for_zero(void)
 
 int main(void)
 {
-   UnityBegin("test_secret_handshake.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_commands_wink_for_1);
    RUN_TEST(test_commands_double_blink_for_10);
@@ -128,5 +128,5 @@ int main(void)
    RUN_TEST(test_commands_reverse_all_possible_actions);
    RUN_TEST(test_commands_do_nothing_for_zero);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/series/test_series.c
+++ b/exercises/practice/series/test_series.c
@@ -133,7 +133,7 @@ static void test_empty_series_is_invalid(void)
 
 int main(void)
 {
-   UnityBegin("test_series.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_slices_of_one_from_one);
    RUN_TEST(test_slices_of_one_from_two);
@@ -146,5 +146,5 @@ int main(void)
    RUN_TEST(test_slice_length_cannot_be_zero);
    RUN_TEST(test_empty_series_is_invalid);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/sieve/test_sieve.c
+++ b/exercises/practice/sieve/test_sieve.c
@@ -111,7 +111,7 @@ static void test_find_primes_up_to_1000(void)
 
 int main(void)
 {
-   UnityBegin("test_sieve.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_no_primes_under_two);
    RUN_TEST(test_find_first_prime);
@@ -120,5 +120,5 @@ int main(void)
    RUN_TEST(test_limit_is_prime_and_small_max_primes);
    RUN_TEST(test_find_primes_up_to_1000);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/space-age/test_space_age.c
+++ b/exercises/practice/space-age/test_space_age.c
@@ -66,7 +66,7 @@ static void test_invalid_planet_causes_error(void)
 
 int main(void)
 {
-   UnityBegin("test_space_age.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_age_on_earth);
    RUN_TEST(test_age_on_mercury);
@@ -78,5 +78,5 @@ int main(void)
    RUN_TEST(test_age_on_neptune);
    RUN_TEST(test_invalid_planet_causes_error);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/square-root/test_square_root.c
+++ b/exercises/practice/square-root/test_square_root.c
@@ -46,7 +46,7 @@ static void test_root_of_65025(void)
 
 int main(void)
 {
-   UnityBegin("test_square_root.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_root_of_1);
    RUN_TEST(test_root_of_4);
@@ -55,5 +55,5 @@ int main(void)
    RUN_TEST(test_root_of_196);
    RUN_TEST(test_root_of_65025);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/sublist/test_sublist.c
+++ b/exercises/practice/sublist/test_sublist.c
@@ -212,7 +212,7 @@ static void test_different_signs(void)
 
 int main(void)
 {
-   UnityBegin("test_sublist.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_empty_lists);
    RUN_TEST(test_empty_list_within_non_empty_list);
@@ -234,5 +234,5 @@ int main(void)
    RUN_TEST(test_same_digits_but_different_numbers);
    RUN_TEST(test_different_signs);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/sum-of-multiples/test_sum_of_multiples.c
+++ b/exercises/practice/sum-of-multiples/test_sum_of_multiples.c
@@ -129,7 +129,7 @@ test_solutions_using_include_exclude_must_extend_to_cardinality_greater_than_3(
 
 int main(void)
 {
-   UnityBegin("test_sum_of_multiples.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_no_multiples_within_limit);
    RUN_TEST(test_one_factor_has_multiples_within_limit);
@@ -150,5 +150,5 @@ int main(void)
    RUN_TEST(
        test_solutions_using_include_exclude_must_extend_to_cardinality_greater_than_3);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/triangle/test_triangle.c
+++ b/exercises/practice/triangle/test_triangle.c
@@ -158,7 +158,7 @@ static void test_scalene_triangle_sides_may_be_floats(void)
 
 int main(void)
 {
-   UnityBegin("test_triangle.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_equilateral_triangle_all_sides_are_equal);
    RUN_TEST(test_equilateral_triangle_if_any_side_is_unequal);
@@ -182,5 +182,5 @@ int main(void)
    RUN_TEST(test_scalene_triangle_may_not_violate_triangle_inequality);
    RUN_TEST(test_scalene_triangle_sides_may_be_floats);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/two-bucket/test_two_bucket.c
+++ b/exercises/practice/two-bucket/test_two_bucket.c
@@ -129,7 +129,7 @@ static void test_goal_larger_than_both_buckets_is_impossible(void)
 
 int main(void)
 {
-   UnityBegin("test_two_bucket.c");
+   UNITY_BEGIN();
 
    RUN_TEST(
        test_measure_using_bucket_one_of_size_3_and_bucket_two_of_size_5_start_with_bucket_one);
@@ -148,5 +148,5 @@ int main(void)
        test_with_the_same_buckets_but_a_different_goal_then_it_is_possible);
    RUN_TEST(test_goal_larger_than_both_buckets_is_impossible);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/two-fer/test_two_fer.c
+++ b/exercises/practice/two-fer/test_two_fer.c
@@ -40,11 +40,11 @@ static void test_two_fer_another_name_given(void)
 
 int main(void)
 {
-   UnityBegin("test_two_fer.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_two_fer_no_name_given);
    RUN_TEST(test_two_fer_a_name_given);
    RUN_TEST(test_two_fer_another_name_given);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/word-count/test_word_count.c
+++ b/exercises/practice/word-count/test_word_count.c
@@ -483,7 +483,7 @@ static void test_quotation_for_word_with_apostrophe(void)
 
 int main(void)
 {
-   UnityBegin("test_word_count.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_count_one_word);
    RUN_TEST(test_count_one_of_each_word);
@@ -500,5 +500,5 @@ int main(void)
    RUN_TEST(test_alternating_word_separators_not_detected_as_a_word);
    RUN_TEST(test_quotation_for_word_with_apostrophe);
 
-   return UnityEnd();
+   return UNITY_END();
 }

--- a/exercises/practice/wordy/test_wordy.c
+++ b/exercises/practice/wordy/test_wordy.c
@@ -247,7 +247,7 @@ static void test_reject_prefix_notation(void)
 
 int main(void)
 {
-   UnityBegin("test_wordy.c");
+   UNITY_BEGIN();
 
    RUN_TEST(test_just_a_number);
    RUN_TEST(test_addition);
@@ -273,5 +273,5 @@ int main(void)
    RUN_TEST(test_reject_postfix_notation);
    RUN_TEST(test_reject_prefix_notation);
 
-   return UnityEnd();
+   return UNITY_END();
 }


### PR DESCRIPTION
See discussion [here](https://github.com/exercism/c/pull/943#pullrequestreview-1847355007)

Done via:
```
for f in $(find . -name "test_*.c"); do
    sed -i -e 's/UnityBegin\(.*\);/UNITY_BEGIN();/' $f
    sed -i -e 's/UnityEnd/UNITY_END/' $f
done
```