### PR TITLE
Fix run-test for macOS standard tools

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -28,7 +28,7 @@ execute_test () {
         echo "Running tests for ${exercise_name}";
 
         #remove the ignore line
-        sed -i 's/TEST_IGNORE();//' ./test_*.c
+        sed -i='' 's/TEST_IGNORE();//' ./test_*.c
 
         # Copy the examples with the correct name for the exercise
         if [ -e ".meta/example.c" ]
@@ -56,14 +56,15 @@ copy_exercises () {
     then
         local directory="${1}"
         shift
-        echo "Copying ${directory} exercises ${*}"
         mkdir -p "build/${directory}"
         if [ $# -gt 0 ]
         then
+            echo "Copying ${directory} exercises ${*}"
             cd "exercises/${directory}"
             cp -r "$@" "../../build/${directory}/"
             cd "../.."
         else
+            echo "Copying all ${directory} exercises"
             cp -r "exercises/${directory}" "build"
         fi
     fi

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Firstly make sure you have the necessary applications installed (such as `clang-
 If you'd like to run only some of the tests to check your work, you can specify them as arguments to the run-tests script.
 
 ```bash
-~/git/c$ ./bin/run-tests acronym all-your-base allergies
+~/git/c$ ./bin/run-tests -p -e acronym -e all-your-base -e allergies
 ```
 
 ## Test Runner


### PR DESCRIPTION
BSD sed requires an argument with `-i` (backup file extension, disabling
backup file creation by providing an empty string; this is the default for GNU
sed when `-i` is specified without an argument).

Further, `/bin/bash` shipping with macOS 14 doesn't like `${*}` when the
argument list is empty (at least in the context it is used in `run-tests`).
The fix of having a distinct message for the case where `${*}` is empty also
improves the behavior for cases where a version of Bash is used that does not
complain about an empty `${*}`.

This has been tested on macOS Sonoma 14.3, but probably also applies to earlier
versions.