### PR TITLE
Improve the zebra-puzzle.

### DIFF
--- a/exercises/practice/zebra-puzzle/.meta/example.c
+++ b/exercises/practice/zebra-puzzle/.meta/example.c
@@ -165,7 +165,7 @@ struct solution solve_puzzle()
    } while (next_permutation(colors, house_by_color));
 
    assert(num_solutions == 1);
-   return (struct solution) {
+   return (struct solution){
       .drinks_water = nationality_to_string(drinks_water),
       .owns_zebra = nationality_to_string(owns_zebra),
    };

--- a/exercises/practice/zebra-puzzle/.meta/example.c
+++ b/exercises/practice/zebra-puzzle/.meta/example.c
@@ -41,7 +41,7 @@ static bool next_permutation(int order[NUM_HOUSES], int by_value[NUM_HOUSES])
       swap(order + a, order + b);
 
    // update the affected elements of by_value
-   for (size_t i = idx1; i < NUM_HOUSES; ++i)
+   for (size_t i = idx1; i < len; ++i)
       by_value[order[i]] = i;
    return true;
 }
@@ -52,11 +52,28 @@ enum animal { DOG, FOX, HORSE, SNAILS, ZEBRA };
 enum drink { COFFEE, MILK, ORANGE_JUICE, TEA, WATER };
 enum smoke { CHESTERFIELD, KOOL, LUCKY_STRIKE, OLD_GOLD, PARLIAMENT };
 
-static void solve(const char **out_drinks_water, const char **out_owns_zebra)
+static const char *nationality_to_string(enum nationality nationality)
+{
+   switch (nationality) {
+      case ENGLISH:
+         return "English";
+      case JAPANESE:
+         return "Japanese";
+      case NORWEGIAN:
+         return "Norwegian";
+      case SPANISH:
+         return "Spanish";
+      case UKRAINIAN:
+         return "Ukrainian";
+   }
+   assert(false);
+}
+
+struct solution solve_puzzle()
 {
    int num_solutions = 0;
-   int drinks_water = -1;
-   int owns_zebra = -1;
+   enum nationality drinks_water = -1;
+   enum nationality owns_zebra = -1;
 
    int colors[] = { BLUE, GREEN, IVORY, RED, YELLOW };
    int house_by_color[] = { 0, 1, 2, 3, 4 };
@@ -148,56 +165,8 @@ static void solve(const char **out_drinks_water, const char **out_owns_zebra)
    } while (next_permutation(colors, house_by_color));
 
    assert(num_solutions == 1);
-   switch (drinks_water) {
-      case ENGLISH:
-         *out_drinks_water = "English";
-         break;
-      case JAPANESE:
-         *out_drinks_water = "Japanese";
-         break;
-      case NORWEGIAN:
-         *out_drinks_water = "Norwegian";
-         break;
-      case SPANISH:
-         *out_drinks_water = "Spanish";
-         break;
-      case UKRAINIAN:
-         *out_drinks_water = "Ukrainian";
-         break;
-      default:
-         assert(false);
-   }
-   switch (owns_zebra) {
-      case ENGLISH:
-         *out_owns_zebra = "English";
-         break;
-      case JAPANESE:
-         *out_owns_zebra = "Japanese";
-         break;
-      case NORWEGIAN:
-         *out_owns_zebra = "Norwegian";
-         break;
-      case SPANISH:
-         *out_owns_zebra = "Spanish";
-         break;
-      case UKRAINIAN:
-         *out_owns_zebra = "Ukrainian";
-         break;
-      default:
-         assert(false);
-   }
-}
-
-const char *drinks_water(void)
-{
-   const char *result, *dummy;
-   solve(&result, &dummy);
-   return result;
-}
-
-const char *owns_zebra(void)
-{
-   const char *result, *dummy;
-   solve(&dummy, &result);
-   return result;
+   return (struct solution) {
+      .drinks_water = nationality_to_string(drinks_water),
+      .owns_zebra = nationality_to_string(owns_zebra),
+   };
 }

--- a/exercises/practice/zebra-puzzle/.meta/example.c
+++ b/exercises/practice/zebra-puzzle/.meta/example.c
@@ -69,7 +69,7 @@ static const char *nationality_to_string(enum nationality nationality)
    assert(false);
 }
 
-struct solution solve_puzzle()
+solution_t solve_puzzle()
 {
    int num_solutions = 0;
    enum nationality drinks_water = -1;
@@ -165,7 +165,7 @@ struct solution solve_puzzle()
    } while (next_permutation(colors, house_by_color));
 
    assert(num_solutions == 1);
-   return (struct solution){
+   return (solution_t){
       .drinks_water = nationality_to_string(drinks_water),
       .owns_zebra = nationality_to_string(owns_zebra),
    };

--- a/exercises/practice/zebra-puzzle/.meta/example.h
+++ b/exercises/practice/zebra-puzzle/.meta/example.h
@@ -1,10 +1,12 @@
 #ifndef ZEBRA_PUZZLE_H
 #define ZEBRA_PUZZLE_H
 
-/// Determine the nationality of the resident who drinks water.
-const char *drinks_water(void);
+struct solution
+{
+   const char *drinks_water;
+   const char *owns_zebra;
+};
 
-/// Determine the nationality of the resident who owns the zebra.
-const char *owns_zebra(void);
+struct solution solve_puzzle(void);
 
 #endif

--- a/exercises/practice/zebra-puzzle/.meta/example.h
+++ b/exercises/practice/zebra-puzzle/.meta/example.h
@@ -1,11 +1,11 @@
 #ifndef ZEBRA_PUZZLE_H
 #define ZEBRA_PUZZLE_H
 
-struct solution {
+typedef struct {
    const char *drinks_water;
    const char *owns_zebra;
-};
+} solution_t;
 
-struct solution solve_puzzle(void);
+solution_t solve_puzzle(void);
 
 #endif

--- a/exercises/practice/zebra-puzzle/.meta/example.h
+++ b/exercises/practice/zebra-puzzle/.meta/example.h
@@ -1,8 +1,7 @@
 #ifndef ZEBRA_PUZZLE_H
 #define ZEBRA_PUZZLE_H
 
-struct solution
-{
+struct solution {
    const char *drinks_water;
    const char *owns_zebra;
 };

--- a/exercises/practice/zebra-puzzle/test_zebra_puzzle.c
+++ b/exercises/practice/zebra-puzzle/test_zebra_puzzle.c
@@ -11,14 +11,14 @@ void tearDown(void)
 
 static void test_who_drinks_water(void)
 {
-   struct solution solution = solve_puzzle();
+   solution_t solution = solve_puzzle();
    TEST_ASSERT_EQUAL_STRING("Norwegian", solution.drinks_water);
 }
 
 static void test_who_owns_the_zebra(void)
 {
    TEST_IGNORE();   // delete this line to run test
-   struct solution solution = solve_puzzle();
+   solution_t solution = solve_puzzle();
    TEST_ASSERT_EQUAL_STRING("Japanese", solution.owns_zebra);
 }
 

--- a/exercises/practice/zebra-puzzle/test_zebra_puzzle.c
+++ b/exercises/practice/zebra-puzzle/test_zebra_puzzle.c
@@ -11,13 +11,15 @@ void tearDown(void)
 
 static void test_who_drinks_water(void)
 {
-   TEST_ASSERT_EQUAL_STRING("Norwegian", drinks_water());
+   struct solution solution = solve_puzzle();
+   TEST_ASSERT_EQUAL_STRING("Norwegian", solution.drinks_water);
 }
 
 static void test_who_owns_the_zebra(void)
 {
    TEST_IGNORE();   // delete this line to run test
-   TEST_ASSERT_EQUAL_STRING("Japanese", owns_zebra());
+   struct solution solution = solve_puzzle();
+   TEST_ASSERT_EQUAL_STRING("Japanese", solution.owns_zebra);
 }
 
 int main(void)

--- a/exercises/practice/zebra-puzzle/zebra_puzzle.h
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle.h
@@ -1,10 +1,12 @@
 #ifndef ZEBRA_PUZZLE_H
 #define ZEBRA_PUZZLE_H
 
-/// Determine the nationality of the resident who drinks water.
-const char *drinks_water(void);
+struct solution
+{
+   const char *drinks_water;
+   const char *owns_zebra;
+};
 
-/// Determine the nationality of the resident who owns the zebra.
-const char *owns_zebra(void);
+struct solution solve_puzzle(void);
 
 #endif

--- a/exercises/practice/zebra-puzzle/zebra_puzzle.h
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle.h
@@ -6,6 +6,6 @@ typedef struct {
    const char *owns_zebra;
 } solution_t;
 
-struct solution solve_puzzle(void);
+solution_t solve_puzzle(void);
 
 #endif

--- a/exercises/practice/zebra-puzzle/zebra_puzzle.h
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle.h
@@ -1,8 +1,7 @@
 #ifndef ZEBRA_PUZZLE_H
 #define ZEBRA_PUZZLE_H
 
-struct solution
-{
+struct solution {
    const char *drinks_water;
    const char *owns_zebra;
 };

--- a/exercises/practice/zebra-puzzle/zebra_puzzle.h
+++ b/exercises/practice/zebra-puzzle/zebra_puzzle.h
@@ -1,10 +1,10 @@
 #ifndef ZEBRA_PUZZLE_H
 #define ZEBRA_PUZZLE_H
 
-struct solution {
+typedef struct {
    const char *drinks_water;
    const char *owns_zebra;
-};
+} solution_t;
 
 struct solution solve_puzzle(void);
 


### PR DESCRIPTION
Following the discussion at <https://github.com/exercism/c/pull/959#discussion_r1501899860>, this PR changes the API of the solution. Instead of two formally independent functions for the two sub-tasks the tests now require a single function that returns a `struct` with the two answers. That should reduce the boilerplate that students will have to write.

It also improves some small details of the example solution.