### PR TITLE
Re-rank and re-order exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -427,7 +427,6 @@
         "difficulty": 4,
         "topics": [
           "control_flow_if_statements",
-          "preprocessor_x_macros_in_test",
           "strings",
           "text_formatting"
         ]
@@ -491,7 +490,12 @@
         "uuid": "f1ad3d6e-7fc2-4461-8ea2-554c2fa9f1f0",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4
+        "difficulty": 4,
+        "topics": [
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "strings"
+        ]
       },
       {
         "slug": "beer-song",

--- a/config.json
+++ b/config.json
@@ -49,44 +49,27 @@
         ]
       },
       {
-        "slug": "armstrong-numbers",
-        "name": "Armstrong Numbers",
-        "uuid": "a4658ee9-b71c-4764-9652-7ed83d46516b",
+        "slug": "leap",
+        "name": "Leap",
+        "uuid": "9b047dda-b85e-4378-9487-9f9cce086e4f",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
         "topics": [
           "control_flow_if_else_statements",
+          "logic"
+        ]
+      },
+      {
+        "slug": "difference-of-squares",
+        "name": "Difference of Squares",
+        "uuid": "9802cbc0-eb70-4840-b8ee-a228f1fc29ea",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "topics": [
           "control_flow_loops",
-          "logic",
           "math"
-        ]
-      },
-      {
-        "slug": "isogram",
-        "name": "Isogram",
-        "uuid": "b3c9d339-60bc-48fe-84ba-77cbc0017a89",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "arrays",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "strings"
-        ]
-      },
-      {
-        "slug": "hamming",
-        "name": "Hamming",
-        "uuid": "fa5e6bbb-2eaf-484f-a5c5-de5cb2a9175b",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "arrays",
-          "control_flow_loops",
-          "strings"
         ]
       },
       {
@@ -103,129 +86,12 @@
         ]
       },
       {
-        "slug": "difference-of-squares",
-        "name": "Difference of Squares",
-        "uuid": "9802cbc0-eb70-4840-b8ee-a228f1fc29ea",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "control_flow_loops",
-          "math"
-        ]
-      },
-      {
-        "slug": "square-root",
-        "name": "Square Root",
-        "uuid": "0400f52d-48ae-4300-a72e-32e8a08514d0",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "bitwise_operations",
-          "control_flow_loops",
-          "math"
-        ]
-      },
-      {
-        "slug": "grade-school",
-        "name": "Grade School",
-        "uuid": "68b1de28-7c3d-4e8c-ab51-7abe6779e187",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "pointers",
-          "sorting",
-          "strings",
-          "structs"
-        ]
-      },
-      {
-        "slug": "binary-search",
-        "name": "Binary Search",
-        "uuid": "db1771d2-afd8-4e01-9b6a-6be75029ef1d",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "arrays",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "searching"
-        ]
-      },
-      {
-        "slug": "rational-numbers",
-        "name": "Rational Numbers",
-        "uuid": "c3325db9-8067-4c2f-94b3-b5190b056d38",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "math",
-          "structs"
-        ]
-      },
-      {
-        "slug": "circular-buffer",
-        "name": "Circular Buffer",
-        "uuid": "c54a33a3-8c6f-4964-b770-b602d207fa20",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "buffers",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "flexible_array_members",
-          "memory_management",
-          "pointers",
-          "structs"
-        ]
-      },
-      {
-        "slug": "list-ops",
-        "name": "List Ops",
-        "uuid": "27a56356-d3ad-41d2-923c-2a58fbb36454",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "flexible_array_members",
-          "function_pointers",
-          "memory_management",
-          "pointers",
-          "structs"
-        ]
-      },
-      {
-        "slug": "reverse-string",
-        "name": "Reverse String",
-        "uuid": "a540d3d9-3c8b-46f5-a150-983308e02289",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "loops",
-          "memory_management",
-          "strings"
-        ]
-      },
-      {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "75653d83-1a64-472c-ac43-49e87833c7f7",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
+        "difficulty": 1,
         "topics": [
           "arrays",
           "enums",
@@ -233,130 +99,14 @@
         ]
       },
       {
-        "slug": "pythagorean-triplet",
-        "name": "Pythagorean Triplet",
-        "uuid": "7b7c61f4-2849-46b7-9057-900bb6b95052",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "arrays",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "flexible_array_members",
-          "memory_management",
-          "structs"
-        ]
-      },
-      {
-        "slug": "saddle-points",
-        "name": "Saddle Points",
-        "uuid": "448f9137-4e58-4c26-9853-abe07f01c908",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "arrays",
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "flexible_array_members",
-          "memory_management",
-          "structs"
-        ]
-      },
-      {
-        "slug": "allergies",
-        "name": "Allergies",
-        "uuid": "871f1c41-debd-4807-8ee5-bde54c3918f8",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "control_flow_if_statements",
-          "control_flow_loops",
-          "memory_management",
-          "structs"
-        ]
-      },
-      {
-        "slug": "phone-number",
-        "name": "Phone Number",
-        "uuid": "660d1586-c4e0-4537-94b5-455a983820f8",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "memory_management",
-          "strings"
-        ]
-      },
-      {
-        "slug": "clock",
-        "name": "Clock",
-        "uuid": "b868eeff-400c-4e46-8675-10d85c14b503",
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "5a47f8a5-36a1-4479-bb77-ef5fbab4bae0",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
         "topics": [
-          "control_flow_if_statements",
-          "preprocessor_x_macros_in_test",
-          "strings",
-          "text_formatting"
-        ]
-      },
-      {
-        "slug": "sieve",
-        "name": "Sieve",
-        "uuid": "fb2530a3-cbbf-4ba9-88d0-203faac03e96",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_if_statements",
-          "math",
-          "memory_management"
-        ]
-      },
-      {
-        "slug": "robot-simulator",
-        "name": "Robot Simulator",
-        "uuid": "e665da31-fda2-4bce-94e9-7d79dffdef14",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_if_statements",
-          "pointers",
-          "strings",
-          "structs",
-          "variable_argument_lists"
-        ]
-      },
-      {
-        "slug": "pascals-triangle",
-        "name": "Pascal's Triangle",
-        "uuid": "be19352f-1b63-4673-9a2d-e763ee807741",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "control_flow_if_else_statements",
-          "math",
-          "memory_management"
-        ]
-      },
-      {
-        "slug": "binary",
-        "name": "Binary",
-        "uuid": "8621177c-1068-4610-bf5b-26cf23340ae6",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "control_flow_if_statements",
-          "control_flow_loops",
+          "functions",
           "math"
         ]
       },
@@ -366,25 +116,11 @@
         "uuid": "b0a152e9-5a45-41f9-bda0-427111d9a56c",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "control_flow_if_statements",
           "enums",
           "functions",
-          "structs"
-        ]
-      },
-      {
-        "slug": "linked-list",
-        "name": "Linked List",
-        "uuid": "58107e5f-8091-4429-9130-13f2c7dac9a9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "functions",
-          "lists",
-          "pointers",
           "structs"
         ]
       },
@@ -394,7 +130,7 @@
         "uuid": "a579e471-86f3-4f29-82ca-e984a2cc8891",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "control_flow_if_else_statements",
           "logic",
@@ -407,47 +143,23 @@
         "uuid": "93271b2e-8ad9-4e7d-8732-5988140e8c00",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "arrays",
           "enums"
         ]
       },
       {
-        "slug": "resistor-color-trio",
-        "name": "Resistor Color Trio",
-        "uuid": "6cd7bb9c-2817-4c44-8bef-5f2916b2db2d",
+        "slug": "hamming",
+        "name": "Hamming",
+        "uuid": "fa5e6bbb-2eaf-484f-a5c5-de5cb2a9175b",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "arrays",
-          "enums",
-          "structs"
-        ]
-      },
-      {
-        "slug": "acronym",
-        "name": "Acronym",
-        "uuid": "1a8ba121-d2c4-4994-8c6b-610d8987346d",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
           "control_flow_loops",
-          "memory_management",
           "strings"
-        ]
-      },
-      {
-        "slug": "gigasecond",
-        "name": "Gigasecond",
-        "uuid": "000340f6-e30d-4d49-a255-016237d6fe60",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "dates"
         ]
       },
       {
@@ -456,9 +168,84 @@
         "uuid": "fc03c7de-b0c6-4806-90bb-e9dda846e660",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
+        "difficulty": 2,
         "topics": [
           "functions"
+        ]
+      },
+      {
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "uuid": "d12fea98-bf4e-476d-a91c-799fc98a1690",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "control_flow_case_statements",
+          "control_flow_loops",
+          "strings"
+        ]
+      },
+      {
+        "slug": "binary",
+        "name": "Binary",
+        "uuid": "8621177c-1068-4610-bf5b-26cf23340ae6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "control_flow_if_statements",
+          "control_flow_loops",
+          "math"
+        ]
+      },
+      {
+        "slug": "eliuds-eggs",
+        "name": "Eliud's Eggs",
+        "uuid": "8a813e24-6263-437d-a610-7f5da1456b7f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "bitwise_operations",
+          "control_flow_if_statements",
+          "control_flow_loops"
+        ]
+      },
+      {
+        "slug": "two-fer",
+        "name": "Two Fer",
+        "uuid": "15653c72-5468-415f-9425-6c58d552d346",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "control_flow_if_statements",
+          "strings"
+        ]
+      },
+      {
+        "slug": "raindrops",
+        "name": "Raindrops",
+        "uuid": "93acdd0d-9bd1-4dec-a572-fd12d0c66187",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "control_flow_if_else_statements",
+          "strings"
+        ]
+      },
+      {
+        "slug": "perfect-numbers",
+        "name": "Perfect Numbers",
+        "uuid": "a1168a15-d46f-4541-8b58-68bca0c54733",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "control_flow_if_else_statements",
+          "math"
         ]
       },
       {
@@ -487,210 +274,122 @@
         ]
       },
       {
-        "slug": "word-count",
-        "name": "Word Count",
-        "uuid": "1e4f4fcf-c32d-459f-8920-15ac56008666",
+        "slug": "resistor-color-trio",
+        "name": "Resistor Color Trio",
+        "uuid": "6cd7bb9c-2817-4c44-8bef-5f2916b2db2d",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
         "topics": [
-          "filtering",
-          "memory_management",
-          "strings",
+          "arrays",
+          "enums",
           "structs"
         ]
       },
       {
-        "slug": "rail-fence-cipher",
-        "name": "Rail Fence Cipher",
-        "uuid": "314dcf23-9cd9-4488-b53e-6dee1b303980",
+        "slug": "armstrong-numbers",
+        "name": "Armstrong Numbers",
+        "uuid": "a4658ee9-b71c-4764-9652-7ed83d46516b",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4,
+        "difficulty": 3,
+        "topics": [
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "logic",
+          "math"
+        ]
+      },
+      {
+        "slug": "isogram",
+        "name": "Isogram",
+        "uuid": "b3c9d339-60bc-48fe-84ba-77cbc0017a89",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
         "topics": [
           "arrays",
-          "control_flow_if_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "matching-brackets",
-        "name": "Matching Brackets",
-        "uuid": "cd573670-54da-4291-ab78-afd5d77fbeac",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "control_flow_if_statements",
-          "recursion",
-          "stacks"
-        ]
-      },
-      {
-        "slug": "nucleotide-count",
-        "name": "Nucleotide Count",
-        "uuid": "38669990-e1e6-4486-a603-575a135d1f5c",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_loops_switch_if_statements",
-          "memory_management",
-          "strings",
-          "text_formatting"
-        ]
-      },
-      {
-        "slug": "rna-transcription",
-        "name": "RNA Transcription",
-        "uuid": "d12fea98-bf4e-476d-a91c-799fc98a1690",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_case_statements",
+          "control_flow_if_else_statements",
           "control_flow_loops",
           "strings"
         ]
       },
       {
-        "slug": "secret-handshake",
-        "name": "Secret Handshake",
-        "uuid": "119c20a6-849f-412e-b0a6-113a2cedc72d",
+        "slug": "binary-search",
+        "name": "Binary Search",
+        "uuid": "db1771d2-afd8-4e01-9b6a-6be75029ef1d",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
         "topics": [
-          "algorithms",
-          "control_flow_if_statements",
-          "strings"
+          "arrays",
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "searching"
         ]
       },
       {
-        "slug": "protein-translation",
-        "name": "Protein Translation",
-        "uuid": "f1ad3d6e-7fc2-4461-8ea2-554c2fa9f1f0",
+        "slug": "robot-simulator",
+        "name": "Robot Simulator",
+        "uuid": "e665da31-fda2-4bce-94e9-7d79dffdef14",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4
-      },
-      {
-        "slug": "meetup",
-        "name": "Meetup",
-        "uuid": "a7baa53f-e828-457e-a456-ba3471494d80",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
+        "difficulty": 3,
         "topics": [
           "control_flow_if_statements",
-          "preprocessor_x_macros_in_test",
+          "pointers",
           "strings",
           "structs",
-          "time_functions"
+          "variable_argument_lists"
         ]
       },
       {
-        "slug": "pig-latin",
-        "name": "Pig Latin",
-        "uuid": "62f539e7-f682-412d-bf86-38503e7cebca",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "control_flow_if_statements",
-          "functions",
-          "strings"
-        ]
-      },
-      {
-        "slug": "leap",
-        "name": "Leap",
-        "uuid": "9b047dda-b85e-4378-9487-9f9cce086e4f",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "control_flow_if_else_statements",
-          "logic"
-        ]
-      },
-      {
-        "slug": "two-fer",
-        "name": "Two Fer",
-        "uuid": "15653c72-5468-415f-9425-6c58d552d346",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "control_flow_if_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "beer-song",
-        "name": "Beer Song",
-        "uuid": "c06789cb-cdd6-44a7-bee5-16e0d85e913a",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_if_else_statements",
-          "control_flow_loops",
-          "strings"
-        ]
-      },
-      {
-        "slug": "raindrops",
-        "name": "Raindrops",
-        "uuid": "93acdd0d-9bd1-4dec-a572-fd12d0c66187",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_if_else_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "roman-numerals",
-        "name": "Roman Numerals",
-        "uuid": "6cde608f-9819-46cd-884b-dbda39a4fa16",
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "uuid": "000340f6-e30d-4d49-a255-016237d6fe60",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
         "topics": [
-          "arrays",
-          "control_flow_loops",
-          "memory_management",
-          "strings",
+          "dates"
+        ]
+      },
+      {
+        "slug": "triangle",
+        "name": "Triangle",
+        "uuid": "5c6bc8d2-2509-471a-993c-a5bf9d030ca7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "booleans",
+          "control_flow_if_else_statements",
           "structs"
         ]
       },
       {
-        "slug": "wordy",
-        "name": "Wordy",
-        "uuid": "c1392944-08fd-45c3-b508-41d682f832d3",
+        "slug": "luhn",
+        "name": "Luhn",
+        "uuid": "8c0762e6-702e-4733-a0a1-65099e2a46f7",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
         "topics": [
           "algorithms",
-          "control_flow_if_statements",
-          "functions",
           "strings"
         ]
       },
       {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "b0feb5e2-eb94-4393-b60d-cf8a275d1860",
+        "slug": "allergies",
+        "name": "Allergies",
+        "uuid": "871f1c41-debd-4807-8ee5-bde54c3918f8",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5,
+        "difficulty": 4,
         "topics": [
-          "control_flow_if_else_statements",
-          "strings"
+          "control_flow_if_statements",
+          "control_flow_loops",
+          "structs"
         ]
       },
       {
@@ -699,7 +398,7 @@
         "uuid": "472b1a6b-2b7a-4609-a97d-4c2b6c941a1f",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 4,
         "topics": [
           "math",
           "performance_optimizations",
@@ -720,160 +419,91 @@
         ]
       },
       {
-        "slug": "two-bucket",
-        "name": "Two Bucket",
-        "uuid": "d8ecb4c4-2af2-423c-9f39-4adab687ecd6",
+        "slug": "clock",
+        "name": "Clock",
+        "uuid": "b868eeff-400c-4e46-8675-10d85c14b503",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 6,
+        "difficulty": 4,
         "topics": [
-          "algorithms",
-          "control_flow_if_else_statements",
-          "control_flow_loops"
-        ]
-      },
-      {
-        "slug": "anagram",
-        "name": "Anagram",
-        "uuid": "0b64079a-7fec-42b4-bd2e-1b04dd4b7e6e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "filtering",
-          "strings",
-          "structs"
-        ]
-      },
-      {
-        "slug": "binary-search-tree",
-        "name": "Binary Search Tree",
-        "uuid": "1b33f528-8f29-4582-a268-07be2d1a4516",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6,
-        "topics": [
-          "arrays",
-          "control_flow_loops",
-          "recursion",
-          "structs"
-        ]
-      },
-      {
-        "slug": "say",
-        "name": "Say",
-        "uuid": "523fa391-08d4-4c4e-95e6-20335cd157a0",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6,
-        "topics": [
-          "algorithms",
           "control_flow_if_statements",
+          "preprocessor_x_macros_in_test",
+          "strings",
+          "text_formatting"
+        ]
+      },
+      {
+        "slug": "sieve",
+        "name": "Sieve",
+        "uuid": "fb2530a3-cbbf-4ba9-88d0-203faac03e96",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "control_flow_if_statements",
+          "math",
+          "memory_management"
+        ]
+      },
+      {
+        "slug": "square-root",
+        "name": "Square Root",
+        "uuid": "0400f52d-48ae-4300-a72e-32e8a08514d0",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "bitwise_operations",
+          "control_flow_loops",
+          "math"
+        ]
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "a540d3d9-3c8b-46f5-a150-983308e02289",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "loops",
+          "memory_management",
           "strings"
         ]
       },
       {
-        "slug": "etl",
-        "name": "ETL",
-        "uuid": "9b6faac9-10dd-46ff-9d29-7242e74f5c06",
+        "slug": "nucleotide-count",
+        "name": "Nucleotide Count",
+        "uuid": "38669990-e1e6-4486-a603-575a135d1f5c",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 4,
         "topics": [
-          "pointers",
-          "structs"
-        ]
-      },
-      {
-        "slug": "series",
-        "name": "Series",
-        "uuid": "40bcec79-7235-4ac6-b69f-8e3a6374188d",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "control_flow_if_statements",
+          "control_flow_loops_switch_if_statements",
           "memory_management",
           "strings",
           "text_formatting"
         ]
       },
       {
-        "slug": "diamond",
-        "name": "Diamond",
-        "uuid": "8605a296-1c67-4723-84ac-3a25d77ed015",
+        "slug": "protein-translation",
+        "name": "Protein Translation",
+        "uuid": "f1ad3d6e-7fc2-4461-8ea2-554c2fa9f1f0",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "control_flow_if_statements",
-          "functions",
-          "strings"
-        ]
+        "difficulty": 4
       },
       {
-        "slug": "minesweeper",
-        "name": "Minesweeper",
-        "uuid": "2e97072f-9e77-4ddd-9d75-6162a927bab1",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "arrays",
-          "control_flow_if_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "run-length-encoding",
-        "name": "Run-Length Encoding",
-        "uuid": "b22152b9-99d1-411c-8cf2-f89e8f5f8141",
+        "slug": "beer-song",
+        "name": "Beer Song",
+        "uuid": "c06789cb-cdd6-44a7-bee5-16e0d85e913a",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
         "topics": [
-          "algorithms",
-          "control_flow_if_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "atbash-cipher",
-        "name": "Atbash Cipher",
-        "uuid": "180f59f3-78ab-4368-9fa7-e3d98a9dca78",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
           "control_flow_if_else_statements",
           "control_flow_loops",
           "strings"
-        ]
-      },
-      {
-        "slug": "crypto-square",
-        "name": "Crypto Square",
-        "uuid": "23c2a169-eea2-4636-af62-4a77a4dc3d7b",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6,
-        "topics": [
-          "algorithms",
-          "control_flow_if_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "react",
-        "name": "React",
-        "uuid": "929b651e-2017-4f98-b2cb-1dc46c609703",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 10,
-        "topics": [
-          "functions",
-          "memory_management"
         ]
       },
       {
@@ -882,7 +512,7 @@
         "uuid": "f34db12c-7acc-4287-92a6-c077938512d7",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 4,
         "topics": [
           "algorithms",
           "math"
@@ -903,81 +533,31 @@
         ]
       },
       {
-        "slug": "perfect-numbers",
-        "name": "Perfect Numbers",
-        "uuid": "a1168a15-d46f-4541-8b58-68bca0c54733",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "control_flow_if_else_statements",
-          "math"
-        ]
-      },
-      {
-        "slug": "triangle",
-        "name": "Triangle",
-        "uuid": "5c6bc8d2-2509-471a-993c-a5bf9d030ca7",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "booleans",
-          "control_flow_if_else_statements",
-          "structs"
-        ]
-      },
-      {
-        "slug": "collatz-conjecture",
-        "name": "Collatz Conjecture",
-        "uuid": "5a47f8a5-36a1-4479-bb77-ef5fbab4bae0",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "functions",
-          "math"
-        ]
-      },
-      {
-        "slug": "luhn",
-        "name": "Luhn",
-        "uuid": "8c0762e6-702e-4733-a0a1-65099e2a46f7",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "algorithms",
-          "strings"
-        ]
-      },
-      {
-        "slug": "palindrome-products",
-        "name": "Palindrome Products",
-        "uuid": "8dd43f6c-37ba-42b1-bb85-9ad693e4ce03",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "functions",
-          "math",
-          "pointers",
-          "strings",
-          "structs"
-        ]
-      },
-      {
         "slug": "all-your-base",
         "name": "All Your Base",
         "uuid": "e3574f75-89cb-4dda-8fce-14ce3141b595",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
+        "difficulty": 4,
         "topics": [
           "arrays",
           "control_flow_if_else_statements",
           "control_flow_loops",
           "math"
+        ]
+      },
+      {
+        "slug": "yacht",
+        "name": "Yacht",
+        "uuid": "dd360788-1dff-4a5d-89af-5bbd1199ae86",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "arrays",
+          "control_flow_if_statements",
+          "control_flow_loops",
+          "structs"
         ]
       },
       {
@@ -1010,12 +590,428 @@
         ]
       },
       {
+        "slug": "kindergarten-garden",
+        "name": "Kindergarten Garden",
+        "uuid": "9484317e-d638-4714-afba-2a10baccff16",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "arrays",
+          "control_flow_loops",
+          "strings",
+          "structs"
+        ]
+      },
+      {
+        "slug": "spiral-matrix",
+        "name": "Spiral Matrix",
+        "uuid": "2e5f7544-68fc-4993-9ee0-27b74b1176e7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_loops",
+          "memory_management",
+          "pointers"
+        ]
+      },
+      {
+        "slug": "grade-school",
+        "name": "Grade School",
+        "uuid": "68b1de28-7c3d-4e8c-ab51-7abe6779e187",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "pointers",
+          "sorting",
+          "strings",
+          "structs"
+        ]
+      },
+      {
+        "slug": "rational-numbers",
+        "name": "Rational Numbers",
+        "uuid": "c3325db9-8067-4c2f-94b3-b5190b056d38",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "math",
+          "structs"
+        ]
+      },
+      {
+        "slug": "circular-buffer",
+        "name": "Circular Buffer",
+        "uuid": "c54a33a3-8c6f-4964-b770-b602d207fa20",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "buffers",
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "flexible_array_members",
+          "memory_management",
+          "pointers",
+          "structs"
+        ]
+      },
+      {
+        "slug": "list-ops",
+        "name": "List Ops",
+        "uuid": "27a56356-d3ad-41d2-923c-2a58fbb36454",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "flexible_array_members",
+          "function_pointers",
+          "memory_management",
+          "pointers",
+          "structs"
+        ]
+      },
+      {
+        "slug": "saddle-points",
+        "name": "Saddle Points",
+        "uuid": "448f9137-4e58-4c26-9853-abe07f01c908",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "flexible_array_members",
+          "memory_management",
+          "structs"
+        ]
+      },
+      {
+        "slug": "phone-number",
+        "name": "Phone Number",
+        "uuid": "660d1586-c4e0-4537-94b5-455a983820f8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "pascals-triangle",
+        "name": "Pascal's Triangle",
+        "uuid": "be19352f-1b63-4673-9a2d-e763ee807741",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_if_else_statements",
+          "math",
+          "memory_management"
+        ]
+      },
+      {
+        "slug": "acronym",
+        "name": "Acronym",
+        "uuid": "1a8ba121-d2c4-4994-8c6b-610d8987346d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_loops",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "matching-brackets",
+        "name": "Matching Brackets",
+        "uuid": "cd573670-54da-4291-ab78-afd5d77fbeac",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_if_statements",
+          "recursion",
+          "stacks"
+        ]
+      },
+      {
+        "slug": "roman-numerals",
+        "name": "Roman Numerals",
+        "uuid": "6cde608f-9819-46cd-884b-dbda39a4fa16",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_loops",
+          "memory_management",
+          "strings",
+          "structs"
+        ]
+      },
+      {
+        "slug": "anagram",
+        "name": "Anagram",
+        "uuid": "0b64079a-7fec-42b4-bd2e-1b04dd4b7e6e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "filtering",
+          "strings",
+          "structs"
+        ]
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "b0feb5e2-eb94-4393-b60d-cf8a275d1860",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_if_else_statements",
+          "strings"
+        ]
+      },
+      {
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "uuid": "119c20a6-849f-412e-b0a6-113a2cedc72d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "control_flow_if_statements",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "etl",
+        "name": "ETL",
+        "uuid": "9b6faac9-10dd-46ff-9d29-7242e74f5c06",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "memory_management",
+          "pointers",
+          "structs"
+        ]
+      },
+      {
+        "slug": "series",
+        "name": "Series",
+        "uuid": "40bcec79-7235-4ac6-b69f-8e3a6374188d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_if_statements",
+          "memory_management",
+          "strings",
+          "text_formatting"
+        ]
+      },
+      {
+        "slug": "diamond",
+        "name": "Diamond",
+        "uuid": "8605a296-1c67-4723-84ac-3a25d77ed015",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_if_statements",
+          "functions",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "minesweeper",
+        "name": "Minesweeper",
+        "uuid": "2e97072f-9e77-4ddd-9d75-6162a927bab1",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "arrays",
+          "control_flow_if_statements",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "run-length-encoding",
+        "name": "Run-Length Encoding",
+        "uuid": "b22152b9-99d1-411c-8cf2-f89e8f5f8141",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "control_flow_if_statements",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "atbash-cipher",
+        "name": "Atbash Cipher",
+        "uuid": "180f59f3-78ab-4368-9fa7-e3d98a9dca78",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "pythagorean-triplet",
+        "name": "Pythagorean Triplet",
+        "uuid": "7b7c61f4-2849-46b7-9057-900bb6b95052",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "arrays",
+          "control_flow_if_else_statements",
+          "control_flow_loops",
+          "flexible_array_members",
+          "memory_management",
+          "structs"
+        ]
+      },
+      {
+        "slug": "linked-list",
+        "name": "Linked List",
+        "uuid": "58107e5f-8091-4429-9130-13f2c7dac9a9",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "functions",
+          "lists",
+          "memory_management",
+          "pointers",
+          "structs"
+        ]
+      },
+      {
+        "slug": "word-count",
+        "name": "Word Count",
+        "uuid": "1e4f4fcf-c32d-459f-8920-15ac56008666",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "filtering",
+          "memory_management",
+          "strings",
+          "structs"
+        ]
+      },
+      {
+        "slug": "rail-fence-cipher",
+        "name": "Rail Fence Cipher",
+        "uuid": "314dcf23-9cd9-4488-b53e-6dee1b303980",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "arrays",
+          "control_flow_if_statements",
+          "strings"
+        ]
+      },
+      {
+        "slug": "meetup",
+        "name": "Meetup",
+        "uuid": "a7baa53f-e828-457e-a456-ba3471494d80",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "control_flow_if_statements",
+          "preprocessor_x_macros_in_test",
+          "strings",
+          "structs",
+          "time_functions"
+        ]
+      },
+      {
+        "slug": "pig-latin",
+        "name": "Pig Latin",
+        "uuid": "62f539e7-f682-412d-bf86-38503e7cebca",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "algorithms",
+          "control_flow_if_statements",
+          "functions",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
+        "slug": "wordy",
+        "name": "Wordy",
+        "uuid": "c1392944-08fd-45c3-b508-41d682f832d3",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "algorithms",
+          "control_flow_if_statements",
+          "functions",
+          "strings"
+        ]
+      },
+      {
+        "slug": "crypto-square",
+        "name": "Crypto Square",
+        "uuid": "23c2a169-eea2-4636-af62-4a77a4dc3d7b",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "algorithms",
+          "control_flow_if_statements",
+          "memory_management",
+          "strings"
+        ]
+      },
+      {
         "slug": "largest-series-product",
         "name": "Largest Series Product",
         "uuid": "4b5974fe-dcff-4542-ad3e-2782201cba1e",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5,
+        "difficulty": 6,
         "topics": [
           "control_flow_loops",
           "math",
@@ -1024,38 +1020,52 @@
         ]
       },
       {
-        "slug": "kindergarten-garden",
-        "name": "Kindergarten Garden",
-        "uuid": "9484317e-d638-4714-afba-2a10baccff16",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "arrays",
-          "control_flow_loops",
-          "strings"
-        ]
-      },
-      {
-        "slug": "eliuds-eggs",
-        "name": "Eliud's Eggs",
-        "uuid": "8a813e24-6263-437d-a610-7f5da1456b7f",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "bitwise_operations",
-          "control_flow_if_statements",
-          "control_flow_loops"
-        ]
-      },
-      {
         "slug": "zebra-puzzle",
         "name": "Zebra Puzzle",
         "uuid": "2cae2796-5c05-4159-b3e7-9f5653f0bc9b",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 6
+        "difficulty": 7
+      },
+      {
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "d8ecb4c4-2af2-423c-9f39-4adab687ecd6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7,
+        "topics": [
+          "algorithms",
+          "control_flow_if_else_statements",
+          "control_flow_loops"
+        ]
+      },
+      {
+        "slug": "binary-search-tree",
+        "name": "Binary Search Tree",
+        "uuid": "1b33f528-8f29-4582-a268-07be2d1a4516",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7,
+        "topics": [
+          "arrays",
+          "control_flow_loops",
+          "recursion",
+          "structs"
+        ]
+      },
+      {
+        "slug": "say",
+        "name": "Say",
+        "uuid": "523fa391-08d4-4c4e-95e6-20335cd157a0",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7,
+        "topics": [
+          "algorithms",
+          "control_flow_if_statements",
+          "strings"
+        ]
       },
       {
         "slug": "knapsack",
@@ -1063,33 +1073,34 @@
         "uuid": "caf3784a-400f-425d-b537-a903175503ff",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 7
+        "difficulty": 8
       },
       {
-        "slug": "spiral-matrix",
-        "name": "Spiral Matrix",
-        "uuid": "2e5f7544-68fc-4993-9ee0-27b74b1176e7",
+        "slug": "palindrome-products",
+        "name": "Palindrome Products",
+        "uuid": "8dd43f6c-37ba-42b1-bb85-9ad693e4ce03",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4,
+        "difficulty": 8,
         "topics": [
-          "arrays",
-          "control_flow_loops",
-          "pointers"
+          "functions",
+          "math",
+          "memory_management",
+          "pointers",
+          "strings",
+          "structs"
         ]
       },
       {
-        "slug": "yacht",
-        "name": "Yacht",
-        "uuid": "dd360788-1dff-4a5d-89af-5bbd1199ae86",
+        "slug": "react",
+        "name": "React",
+        "uuid": "929b651e-2017-4f98-b2cb-1dc46c609703",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4,
+        "difficulty": 10,
         "topics": [
-          "arrays",
-          "control_flow_if_statements",
-          "control_flow_loops",
-          "structs"
+          "functions",
+          "memory_management"
         ]
       }
     ]


### PR DESCRIPTION
This definitely isn't perfect, but I think it's a pretty significant improvement over our current state. What I did was:
- Re-assigned difficulties based on gut feel (from my own experience and by looking at our solutions), completion percentages (see https://exercism.org/tracks/c/build), and topics covered (for example, anything with memory management was bumped up to at least a 4 or 5... we had several at 1 and 2 :neutral_face:)
- Ordered all of the exercises by difficulty
- Within the lower difficulty levels, I ordered exercises such that not too much was introduced at a time.

As a next step, I think we can pick a difficulty cut-off point and start adding more complete skeletons to earlier exercises. This would address:
- https://github.com/exercism/c/issues/911
- https://github.com/exercism/c/issues/740

Fixes https://github.com/exercism/c/issues/971
