### PR TITLE
Fix CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism C Track
 
-[![Test Actions Status](https://github.com/exercism/c/workflows/test/badge.svg)](https://github.com/exercism/c/actions)
+[![Test Actions Status](https://github.com/exercism/c/actions/workflows/test.yml/badge.svg)](https://github.com/exercism/c/actions)
 
 Exercism problems in C
 


### PR DESCRIPTION
The image of the CI build status was broken. This fixes it.