### PR TITLE
 queen-attack test that prevents incorrectly accepted answers due to unsigned type.

### DIFF
--- a/exercises/practice/queen-attack/test_queen_attack.c
+++ b/exercises/practice/queen-attack/test_queen_attack.c
@@ -192,6 +192,19 @@ test_cannot_attack_if_falling_diagonals_only_same_when_reflected_across_longest_
    TEST_ASSERT_EQUAL(CAN_NOT_ATTACK, can_attack(white_queen, black_queen));
 }
 
+static void
+test_can_attack_if_queens_crossed_sides_and_on_the_same_diagonal(void)
+{
+   TEST_IGNORE();
+   position_t white_queen;
+   position_t black_queen;
+
+   white_queen.column = 2;
+   white_queen.row = 7;
+   black_queen.column = 6;
+   black_queen.row = 1;
+   TEST_ASSERT_EQUAL(CAN_ATTACK, can_attack(white_queen, black_queen));
+}
 int main(void)
 {
    UNITY_BEGIN();
@@ -210,6 +223,7 @@ int main(void)
    RUN_TEST(test_can_attack_on_fourth_diagonal);
    RUN_TEST(
        test_cannot_attack_if_falling_diagonals_only_same_when_reflected_across_longest_falling_diagonal);
+   RUN_TEST(test_can_attack_if_queens_crossed_sides_and_on_the_same_diagonal);
 
    return UNITY_END();
 }


### PR DESCRIPTION
[Issue: 1011](https://github.com/exercism/c/issues/1011#issue-2515284606)

A lot of user solutions that I've seen use some type of  `abs(queen_1.row - queen_2.row) == abs(queen_1.column - queen_2.column);`. This test make sure that students are taking into account underflow that happens because of the Unsigned int type.

Tests if Queens can attack each other even when they crossed sides of the board, which is a common position on chest. Also it ensure that the students start to take into account overflows/underflows that happens often in C/C++