### PR TITLE
Update test_diamond.c

### DIFF
--- a/exercises/practice/diamond/test_diamond.c
+++ b/exercises/practice/diamond/test_diamond.c
@@ -4,13 +4,8 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 
-void setUp(void)
-{
-}
-
-void tearDown(void)
-{
-}
+void setUp(void) {}
+void tearDown(void) {}
 
 static void test_rows_degenerate_case_with_a_single_a_row(void)
 {
@@ -21,49 +16,38 @@ static void test_rows_degenerate_case_with_a_single_a_row(void)
    free_diamond(diamond);
 }
 
-static void
-test_rows_degenerate_case_with_no_row_with_3_distinct_groups_of_spaces(void)
+static void test_rows_degenerate_case_with_no_row_with_3_distinct_groups_of_spaces(void)
 {
-   TEST_IGNORE();   // delete this line to run test
    const char letter = 'B';
    const char *expected[] = {
-      // clang-format off
       " A ",
       "B B",
       " A "
-      //clang-format on
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
    free_diamond(diamond);
 }
 
-static void
-test_rows_smallest_non_degenerate_case_with_odd_diamond_side_length(void)
+static void test_rows_smallest_non_degenerate_case_with_odd_diamond_side_length(void)
 {
-   TEST_IGNORE();
    const char letter = 'C';
    const char *expected[] = {
-      // clang-format off
       "  A  ",
       " B B ",
       "C   C",
       " B B ",
       "  A  "
-      // clang-format on
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
    free_diamond(diamond);
 }
 
-static void
-test_rows_smallest_non_degenerate_case_with_even_diamond_side_length(void)
+static void test_rows_smallest_non_degenerate_case_with_even_diamond_side_length(void)
 {
-   TEST_IGNORE();
    const char letter = 'D';
    const char *expected[] = {
-      // clang-format off
       "   A   ",
       "  B B  ",
       " C   C ",
@@ -71,7 +55,6 @@ test_rows_smallest_non_degenerate_case_with_even_diamond_side_length(void)
       " C   C ",
       "  B B  ",
       "   A   "
-      // clang-format on
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
@@ -80,10 +63,8 @@ test_rows_smallest_non_degenerate_case_with_even_diamond_side_length(void)
 
 static void test_rows_largest_possible_diamond(void)
 {
-   TEST_IGNORE();
    const char letter = 'Z';
    const char *expected[] = {
-      // clang-format off
       "                         A                         ",
       "                        B B                        ",
       "                       C   C                       ",
@@ -135,7 +116,6 @@ static void test_rows_largest_possible_diamond(void)
       "                       C   C                       ",
       "                        B B                        ",
       "                         A                         "
-      // clang-format on
    };
    char **diamond = make_diamond(letter);
    TEST_ASSERT_EQUAL_STRING_ARRAY(expected, diamond, ARRAY_SIZE(expected));
@@ -147,12 +127,9 @@ int main(void)
    UNITY_BEGIN();
 
    RUN_TEST(test_rows_degenerate_case_with_a_single_a_row);
-   RUN_TEST(
-       test_rows_degenerate_case_with_no_row_with_3_distinct_groups_of_spaces);
-   RUN_TEST(
-       test_rows_smallest_non_degenerate_case_with_odd_diamond_side_length);
-   RUN_TEST(
-       test_rows_smallest_non_degenerate_case_with_even_diamond_side_length);
+   RUN_TEST(test_rows_degenerate_case_with_no_row_with_3_distinct_groups_of_spaces);
+   RUN_TEST(test_rows_smallest_non_degenerate_case_with_odd_diamond_side_length);
+   RUN_TEST(test_rows_smallest_non_degenerate_case_with_even_diamond_side_length);
    RUN_TEST(test_rows_largest_possible_diamond);
 
    return UNITY_END();


### PR DESCRIPTION
I made several improvements to enhance readability and consistency. First, I removed unnecessary comments, such as clang-format and TEST_IGNORE() lines, which made all tests active by default. I also ensured consistent formatting across all functions for better clarity and flow. Additionally, I consolidated the RUN_TEST statements, eliminating line breaks to make the main function more concise. These changes make the code easier to maintain, cleaner, and ready for execution without needing further adjustments to run the tests.