### PR TITLE
Updating test for Crypto Square

### DIFF
--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -4,6 +4,7 @@
   ],
   "contributors": [
     "h-3-0",
+    "jagdish-15",
     "patricksjackson",
     "QLaille",
     "ryanplusplus",

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,9 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
+
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"

--- a/exercises/practice/crypto-square/test_crypto_square.c
+++ b/exercises/practice/crypto-square/test_crypto_square.c
@@ -19,9 +19,19 @@ static void test_empty_text_res_in_an_empty_ciphertext(void)
    free(res);
 }
 
-static void test_lowercase(void)
+static void normalization_res_in_empty_plaintext(void)
 {
    TEST_IGNORE();   // delete this line to run test
+   const char *input = "... --- ...";
+   const char *expected = "";
+   char *res = ciphertext(input);
+   TEST_ASSERT_EQUAL_STRING(expected, res);
+   free(res);
+}
+
+static void test_lowercase(void)
+{
+   TEST_IGNORE();
    const char *input = "A";
    const char *expected = "a";
    char *res = ciphertext(input);
@@ -88,6 +98,7 @@ int main(void)
    UNITY_BEGIN();
 
    RUN_TEST(test_empty_text_res_in_an_empty_ciphertext);
+   RUN_TEST(normalization_res_in_empty_plaintext);
    RUN_TEST(test_lowercase);
    RUN_TEST(test_remove_spaces);
    RUN_TEST(test_remove_punctuation);


### PR DESCRIPTION
### Pull Request: Syncing Tests for Crypto-Square Exercise

This pull request updates the test suite for the **Crypto-Square** exercise to sync it with the problem specification repository. This follows the prior heads-up via [PR](https://github.com/exercism/c/pull/1028).
