### PR TITLE
Adding tests to Bob exercise

### DIFF
--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -9,6 +9,7 @@
     "h-3-0",
     "hintjens",
     "JacobMikkelsen",
+    "jagdish-15",
     "kytrinyx",
     "patricksjackson",
     "QLaille",

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [e162fead-606f-437a-a166-d051915cea8e]
 description = "stating something"
@@ -64,6 +71,7 @@ description = "alternate silence"
 
 [66953780-165b-4e7e-8ce3-4bcb80b6385a]
 description = "multiple line question"
+include = false
 
 [5371ef75-d9ea-4103-bcfa-2da973ddec1b]
 description = "starting with whitespace"
@@ -76,3 +84,7 @@ description = "other whitespace"
 
 [12983553-8601-46a8-92fa-fcaa3bc4a2a0]
 description = "non-question ending with whitespace"
+
+[2c7278ac-f955-4eb4-bf8f-e33eb4116a15]
+description = "multiple line question"
+reimplements = "66953780-165b-4e7e-8ce3-4bcb80b6385a"

--- a/exercises/practice/bob/test_bob.c
+++ b/exercises/practice/bob/test_bob.c
@@ -141,7 +141,7 @@ static void test_multiple_line_question(void)
    TEST_IGNORE();
    TEST_ASSERT_EQUAL_STRING(
        "Whatever.",
-       hey_bob("\nDoes this cryogenic chamber make me look fat?\nNo"));
+       hey_bob("\nDoes this cryogenic chamber make\n me look fat?"));
 }
 
 static void test_starting_with_whitespace(void)

--- a/exercises/practice/bob/test_bob.c
+++ b/exercises/practice/bob/test_bob.c
@@ -140,7 +140,7 @@ static void test_multiple_line_question(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_EQUAL_STRING(
-       "Whatever.",
+       "Sure.",
        hey_bob("\nDoes this cryogenic chamber make\n me look fat?"));
 }
 

--- a/exercises/practice/bob/test_bob.c
+++ b/exercises/practice/bob/test_bob.c
@@ -140,8 +140,7 @@ static void test_multiple_line_question(void)
 {
    TEST_IGNORE();
    TEST_ASSERT_EQUAL_STRING(
-       "Sure.",
-       hey_bob("\nDoes this cryogenic chamber make\n me look fat?"));
+       "Sure.", hey_bob("\nDoes this cryogenic chamber make\n me look fat?"));
 }
 
 static void test_starting_with_whitespace(void)


### PR DESCRIPTION
### Pull Request: Syncing Tests for Bob Exercise

This pull request updates the test suite for the **Bob** exercise to sync it with the problem specification repository. This follows the prior heads-up via [PR](https://github.com/exercism/c/pull/1028).
