### PR TITLE
Updating new tests and rearranging tests for Roman-Numerals

### DIFF
--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -7,6 +7,7 @@
     "Gamecock",
     "gea-migration",
     "h-3-0",
+    "jagdish-15",
     "patricksjackson",
     "QLaille",
     "ryanplusplus",

--- a/exercises/practice/roman-numerals/.meta/example.c
+++ b/exercises/practice/roman-numerals/.meta/example.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #define NUM_OF_ELEMENTS(a) (sizeof(a) / sizeof(a[0]))
-#define MAX_NUMERAL_LENGTH (10)
+#define MAX_NUMERAL_LENGTH (16)
 
 typedef struct {
    char *numeral;
@@ -18,7 +18,7 @@ const numeral_values_t numeral_values[] = {
 
 char *to_roman_numeral(unsigned int number)
 {
-   char *numerals = calloc(sizeof(char), MAX_NUMERAL_LENGTH);
+   char *numerals = calloc(1, sizeof(char) * (MAX_NUMERAL_LENGTH));
 
    for (size_t i = 0; i < NUM_OF_ELEMENTS(numeral_values); i++) {
       while (number >= numeral_values[i].value) {

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -30,6 +30,9 @@ description = "6 is VI"
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9 is IX"
 
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "27 is XXVII"
 
@@ -42,6 +45,9 @@ description = "49 is XLIX"
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "59 is LIX"
 
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "93 is XCIII"
 
@@ -51,11 +57,17 @@ description = "141 is CXLI"
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "163 is CLXIII"
 
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "575 is DLXXV"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "911 is CMXI"
@@ -63,26 +75,17 @@ description = "911 is CMXI"
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1024 is MXXIV"
 
-[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
-description = "3000 is MMM"
-
-[6d1d82d5-bf3e-48af-9139-87d7165ed509]
-description = "16 is XVI"
-
-[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
-description = "66 is LXVI"
-
-[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
-description = "166 is CLXVI"
-
-[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
-description = "666 is DCLXVI"
-
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
 
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"
+
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
+
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
 
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/test_roman_numerals.c
+++ b/exercises/practice/roman-numerals/test_roman_numerals.c
@@ -62,6 +62,12 @@ static void test_9_is_IX(void)
    check_conversion(9, "IX");
 }
 
+static void test_16_is_XVI(void)
+{
+   TEST_IGNORE();
+   check_conversion(16, "XVI");
+}
+
 static void test_27_is_XXVII(void)
 {
    TEST_IGNORE();
@@ -86,6 +92,12 @@ static void test_59_is_LIX(void)
    check_conversion(59, "LIX");
 }
 
+static void test_66_is_LXVI(void)
+{
+   TEST_IGNORE();
+   check_conversion(66, "LXVI");
+}
+
 static void test_93_is_XCIII(void)
 {
    TEST_IGNORE();
@@ -104,6 +116,12 @@ static void test_163_is_CLXIII(void)
    check_conversion(163, "CLXIII");
 }
 
+static void test_166_is_CLXVI(void)
+{
+   TEST_IGNORE();
+   check_conversion(166, "CLXVI");
+}
+
 static void test_402_is_CDII(void)
 {
    TEST_IGNORE();
@@ -114,6 +132,12 @@ static void test_575_is_DLXXV(void)
 {
    TEST_IGNORE();
    check_conversion(575, "DLXXV");
+}
+
+static void test_666_is_DCLXVI(void)
+{
+   TEST_IGNORE();
+   check_conversion(666, "DCLXVI");
 }
 
 static void test_911_is_CMXI(void)
@@ -128,46 +152,28 @@ static void test_1024_is_MXXIV(void)
    check_conversion(1024, "MXXIV");
 }
 
-static void test_3000_is_MMM(void)
-{
-   TEST_IGNORE();
-   check_conversion(3000, "MMM");
-}
-
-static void test_16_is_XVI(void)
-{
-   TEST_IGNORE();
-   check_conversion(16, "XVI");
-}
-
-static void test_66_is_LXVI(void)
-{
-   TEST_IGNORE();
-   check_conversion(66, "LXVI");
-}
-
-static void test_166_is_CLXVI(void)
-{
-   TEST_IGNORE();
-   check_conversion(166, "CLXVI");
-}
-
-static void test_666_is_DCLXVI(void)
-{
-   TEST_IGNORE();
-   check_conversion(666, "DCLXVI");
-}
-
 static void test_1666_is_MDCLXVI(void)
 {
    TEST_IGNORE();
    check_conversion(1666, "MDCLXVI");
 }
 
+static void test_3000_is_MMM(void)
+{
+   TEST_IGNORE();
+   check_conversion(3000, "MMM");
+}
+
 static void test_3001_is_MMMI(void)
 {
    TEST_IGNORE();
    check_conversion(3001, "MMMI");
+}
+
+static void test_3888_is_MMMDCCCLXXXVIII(void)
+{
+   TEST_IGNORE();
+   check_conversion(3888, "MMMDCCCLXXXVIII");
 }
 
 static void test_3999_is_MMMCMXCIX(void)
@@ -187,24 +193,25 @@ int main(void)
    RUN_TEST(test_5_is_V);
    RUN_TEST(test_6_is_VI);
    RUN_TEST(test_9_is_IX);
+   RUN_TEST(test_16_is_XVI);
    RUN_TEST(test_27_is_XXVII);
    RUN_TEST(test_48_is_XLVIII);
    RUN_TEST(test_49_is_XLIX);
    RUN_TEST(test_59_is_LIX);
+   RUN_TEST(test_66_is_LXVI);
    RUN_TEST(test_93_is_XCIII);
    RUN_TEST(test_141_is_CXLI);
    RUN_TEST(test_163_is_CLXIII);
+   RUN_TEST(test_166_is_CLXVI);
    RUN_TEST(test_402_is_CDII);
    RUN_TEST(test_575_is_DLXXV);
+   RUN_TEST(test_666_is_DCLXVI);
    RUN_TEST(test_911_is_CMXI);
    RUN_TEST(test_1024_is_MXXIV);
-   RUN_TEST(test_3000_is_MMM);
-   RUN_TEST(test_16_is_XVI);
-   RUN_TEST(test_66_is_LXVI);
-   RUN_TEST(test_166_is_CLXVI);
-   RUN_TEST(test_666_is_DCLXVI);
    RUN_TEST(test_1666_is_MDCLXVI);
+   RUN_TEST(test_3000_is_MMM);
    RUN_TEST(test_3001_is_MMMI);
+   RUN_TEST(test_3888_is_MMMDCCCLXXXVIII);
    RUN_TEST(test_3999_is_MMMCMXCIX);
 
    return UNITY_END();


### PR DESCRIPTION
### Pull Request: Syncing Tests for Roman-Numerals Exercise

This pull request updates the test suite for the **Roman-Numerals** exercise to sync it with the problem specification repository and rearranges the existing tests to follow numerical order.
