### PR TITLE
Added line to include test requirement

### DIFF
--- a/exercises/practice/circular-buffer/.docs/instructions.md
+++ b/exercises/practice/circular-buffer/.docs/instructions.md
@@ -34,7 +34,9 @@ If the buffer has 7 elements then it is completely full:
 [5][6][7][8][9][3][4]
 ```
 
-When the buffer is full an error will be raised, alerting the client that further writes are blocked until a slot becomes free.
+If the buffer is empty during a read attempt, an error is raised to alert the client.
+
+When the buffer is full, an error is raised to alert the client that further writes are blocked until a slot becomes available.
 
 When the buffer is full, the client can opt to overwrite the oldest data with a forced write.
 In this case, two more elements — A & B — are added and they overwrite the 3 & 4:


### PR DESCRIPTION
I'm still learning C (and PRs) so my skills might not be there yet — but I stumbled hard on the very first test (`test_reading_empty_buffer_fails()`) because I didn't realize I had to set `errno` to a special value.

I thought this change could serve as a small hint for newbies like me to consider how errors are raised in C. I might be overthinking it, though! 