### PR TITLE
Corrects the instructions so that the binary representation is accurate

### DIFF
--- a/exercises/practice/eliuds-eggs/.docs/introduction.md
+++ b/exercises/practice/eliuds-eggs/.docs/introduction.md
@@ -58,7 +58,7 @@ The position information encoding is calculated as follows:
 
 ### Decimal number on the display
 
-16
+8
 
 ### Actual eggs in the coop
 


### PR DESCRIPTION
In the existing instructions, it indicates that the word 0000 1000 in binary would be 16 in decimal. This is incorrect. The correct value for that word is 8.

Since the binary representation is also in an SVG, it is easier to just change the decimal value. The solution is unchanged with this value, but understanding the binary representation is key to solving the exercise.