### PR TITLE
Exercises - Protein Translation - Patch 1 (to clarify biological terminology)

### DIFF
--- a/exercises/practice/protein-translation/.meta/example.c
+++ b/exercises/practice/protein-translation/.meta/example.c
@@ -5,11 +5,11 @@ enum { codon_length = 3 };
 
 typedef struct {
    const char *const codon;
-   aminoacid_t aminoacid;
+   amino_acid_t amino_acid;
    bool stop;
-} aminoacid_translation_t;
+} amino_acid_translation_t;
 
-static const aminoacid_translation_t translations[] = {
+static const amino_acid_translation_t translations[] = {
    { "AUG", Methionine, false },
    { "UUU", Phenylalanine, false },
    { "UUC", Phenylalanine, false },
@@ -45,7 +45,8 @@ protein_t protein(const char *const rna)
             if (translations[j].stop) {
                return protein;
             } else {
-               protein.protein[protein.count++] = translations[j].aminoacid;
+               protein.amino_acids[protein.count++] =
+                   translations[j].amino_acid;
                found_codon = true;
                break;
             }

--- a/exercises/practice/protein-translation/.meta/example.c
+++ b/exercises/practice/protein-translation/.meta/example.c
@@ -5,11 +5,11 @@ enum { codon_length = 3 };
 
 typedef struct {
    const char *const codon;
-   protein_t protein;
+   aminoacid_t aminoacid;
    bool stop;
-} protein_translation_t;
+} aminoacid_translation_t;
 
-static const protein_translation_t translations[] = {
+static const aminoacid_translation_t translations[] = {
    { "AUG", Methionine, false },
    { "UUU", Phenylalanine, false },
    { "UUC", Phenylalanine, false },
@@ -31,9 +31,9 @@ static const protein_translation_t translations[] = {
 static const size_t translation_count =
     sizeof(translations) / sizeof(translations[0]);
 
-proteins_t proteins(const char *const rna)
+protein_t protein(const char *const rna)
 {
-   proteins_t proteins = { .valid = true, .count = 0 };
+   protein_t protein = { .valid = true, .count = 0 };
 
    size_t rna_length = strlen(rna);
 
@@ -43,9 +43,9 @@ proteins_t proteins(const char *const rna)
       for (size_t j = 0; j < translation_count; j++) {
          if (strncmp(rna + i, translations[j].codon, codon_length) == 0) {
             if (translations[j].stop) {
-               return proteins;
+               return protein;
             } else {
-               proteins.proteins[proteins.count++] = translations[j].protein;
+               protein.protein[protein.count++] = translations[j].aminoacid;
                found_codon = true;
                break;
             }
@@ -53,10 +53,10 @@ proteins_t proteins(const char *const rna)
       }
 
       if (!found_codon) {
-         proteins.valid = false;
-         return proteins;
+         protein.valid = false;
+         return protein;
       }
    }
 
-   return proteins;
+   return protein;
 }

--- a/exercises/practice/protein-translation/.meta/example.h
+++ b/exercises/practice/protein-translation/.meta/example.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define MAX_PROTEINS 10
+#define MAX_AMINOACIDS 10
 
 typedef enum {
    Methionine,
@@ -14,14 +14,14 @@ typedef enum {
    Tyrosine,
    Cysteine,
    Tryptophan,
-} protein_t;
+} aminoacid_t;
 
 typedef struct {
    bool valid;
    size_t count;
-   protein_t proteins[MAX_PROTEINS];
-} proteins_t;
+   aminoacid_t protein[MAX_AMINOACIDS];
+} protein_t;
 
-proteins_t proteins(const char *const rna);
+protein_t protein(const char *const rna);
 
 #endif

--- a/exercises/practice/protein-translation/.meta/example.h
+++ b/exercises/practice/protein-translation/.meta/example.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define MAX_AMINOACIDS 10
+#define MAX_AMINO_ACIDS 10
 
 typedef enum {
    Methionine,
@@ -14,12 +14,12 @@ typedef enum {
    Tyrosine,
    Cysteine,
    Tryptophan,
-} aminoacid_t;
+} amino_acid_t;
 
 typedef struct {
    bool valid;
    size_t count;
-   aminoacid_t protein[MAX_AMINOACIDS];
+   amino_acid_t amino_acids[MAX_AMINO_ACIDS];
 } protein_t;
 
 protein_t protein(const char *const rna);

--- a/exercises/practice/protein-translation/protein_translation.h
+++ b/exercises/practice/protein-translation/protein_translation.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define MAX_PROTEINS 10
+#define MAX_AMINOACIDS 10
 
 typedef enum {
    Methionine,
@@ -14,14 +14,14 @@ typedef enum {
    Tyrosine,
    Cysteine,
    Tryptophan,
-} protein_t;
+} aminoacid_t;
 
 typedef struct {
    bool valid;
    size_t count;
-   protein_t proteins[MAX_PROTEINS];
-} proteins_t;
+   aminoacid_t protein[MAX_AMINOACIDS];
+} protein_t;
 
-proteins_t proteins(const char *const rna);
+protein_t protein(const char *const rna);
 
 #endif

--- a/exercises/practice/protein-translation/protein_translation.h
+++ b/exercises/practice/protein-translation/protein_translation.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define MAX_AMINOACIDS 10
+#define MAX_AMINO_ACIDS 10
 
 typedef enum {
    Methionine,
@@ -14,12 +14,12 @@ typedef enum {
    Tyrosine,
    Cysteine,
    Tryptophan,
-} aminoacid_t;
+} amino_acid_t;
 
 typedef struct {
    bool valid;
    size_t count;
-   aminoacid_t protein[MAX_AMINOACIDS];
+   amino_acid_t amino_acids[MAX_AMINO_ACIDS];
 } protein_t;
 
 protein_t protein(const char *const rna);

--- a/exercises/practice/protein-translation/test_protein_translation.c
+++ b/exercises/practice/protein-translation/test_protein_translation.c
@@ -16,7 +16,7 @@ static void assert_protein_match(protein_t expected, protein_t actual)
    if (expected.valid) {
       TEST_ASSERT_EQUAL_size_t(expected.count, actual.count);
       if (expected.count > 0) {
-         TEST_ASSERT_EQUAL_INT_ARRAY(expected.protein, actual.protein,
+         TEST_ASSERT_EQUAL_INT_ARRAY(expected.amino_acids, actual.amino_acids,
                                      expected.count);
       }
    }
@@ -38,7 +38,7 @@ static void test_methionine_rna_sequence(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Methionine },
+      .amino_acids = { Methionine },
    };
    protein_t actual = protein("AUG");
    assert_protein_match(expected, actual);
@@ -50,7 +50,7 @@ static void test_phenylalanine_rna_sequence_1(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Phenylalanine },
+      .amino_acids = { Phenylalanine },
    };
    protein_t actual = protein("UUU");
    assert_protein_match(expected, actual);
@@ -62,7 +62,7 @@ static void test_phenylalanine_rna_sequence_2(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Phenylalanine },
+      .amino_acids = { Phenylalanine },
    };
    protein_t actual = protein("UUC");
    assert_protein_match(expected, actual);
@@ -74,7 +74,7 @@ static void test_leucine_rna_sequence_1(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Leucine },
+      .amino_acids = { Leucine },
    };
    protein_t actual = protein("UUA");
    assert_protein_match(expected, actual);
@@ -86,7 +86,7 @@ static void test_leucine_rna_sequence_2(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Leucine },
+      .amino_acids = { Leucine },
    };
    protein_t actual = protein("UUG");
    assert_protein_match(expected, actual);
@@ -98,7 +98,7 @@ static void test_serine_rna_sequence_1(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Serine },
+      .amino_acids = { Serine },
    };
    protein_t actual = protein("UCU");
    assert_protein_match(expected, actual);
@@ -110,7 +110,7 @@ static void test_serine_rna_sequence_2(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Serine },
+      .amino_acids = { Serine },
    };
    protein_t actual = protein("UCC");
    assert_protein_match(expected, actual);
@@ -122,7 +122,7 @@ static void test_serine_rna_sequence_3(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Serine },
+      .amino_acids = { Serine },
    };
    protein_t actual = protein("UCA");
    assert_protein_match(expected, actual);
@@ -134,7 +134,7 @@ static void test_serine_rna_sequence_4(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Serine },
+      .amino_acids = { Serine },
    };
    protein_t actual = protein("UCG");
    assert_protein_match(expected, actual);
@@ -146,7 +146,7 @@ static void test_tyrosine_rna_sequence_1(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Tyrosine },
+      .amino_acids = { Tyrosine },
    };
    protein_t actual = protein("UAU");
    assert_protein_match(expected, actual);
@@ -158,7 +158,7 @@ static void test_tyrosine_rna_sequence_2(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Tyrosine },
+      .amino_acids = { Tyrosine },
    };
    protein_t actual = protein("UAC");
    assert_protein_match(expected, actual);
@@ -170,7 +170,7 @@ static void test_cysteine_rna_sequence_1(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Cysteine },
+      .amino_acids = { Cysteine },
    };
    protein_t actual = protein("UGU");
    assert_protein_match(expected, actual);
@@ -182,7 +182,7 @@ static void test_cysteine_rna_sequence_2(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Cysteine },
+      .amino_acids = { Cysteine },
    };
    protein_t actual = protein("UGC");
    assert_protein_match(expected, actual);
@@ -194,7 +194,7 @@ static void test_tryptophan_rna_sequence(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Tryptophan },
+      .amino_acids = { Tryptophan },
    };
    protein_t actual = protein("UGG");
    assert_protein_match(expected, actual);
@@ -239,7 +239,7 @@ static void test_sequence_of_two_protein_codons_translates_into_protein(void)
    protein_t expected = {
       .valid = true,
       .count = 2,
-      .protein = { Phenylalanine, Phenylalanine },
+      .amino_acids = { Phenylalanine, Phenylalanine },
    };
    protein_t actual = protein("UUUUUU");
    assert_protein_match(expected, actual);
@@ -252,7 +252,7 @@ test_sequence_of_two_different_protein_codons_translates_into_protein(void)
    protein_t expected = {
       .valid = true,
       .count = 2,
-      .protein = { Leucine, Leucine },
+      .amino_acids = { Leucine, Leucine },
    };
    protein_t actual = protein("UUAUUG");
    assert_protein_match(expected, actual);
@@ -264,7 +264,7 @@ static void test_translate_rna_strand_into_correct_protein_list(void)
    protein_t expected = {
       .valid = true,
       .count = 3,
-      .protein = { Methionine, Phenylalanine, Tryptophan },
+      .amino_acids = { Methionine, Phenylalanine, Tryptophan },
    };
    protein_t actual = protein("AUGUUUUGG");
    assert_protein_match(expected, actual);
@@ -288,7 +288,7 @@ test_translation_stops_if_stop_codon_at_end_of_two_codon_sequence(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Tryptophan },
+      .amino_acids = { Tryptophan },
    };
    protein_t actual = protein("UGGUAG");
    assert_protein_match(expected, actual);
@@ -301,7 +301,7 @@ test_translation_stops_if_stop_codon_at_end_of_three_codon_sequence(void)
    protein_t expected = {
       .valid = true,
       .count = 2,
-      .protein = { Methionine, Phenylalanine },
+      .amino_acids = { Methionine, Phenylalanine },
    };
    protein_t actual = protein("AUGUUUUAA");
    assert_protein_match(expected, actual);
@@ -314,7 +314,7 @@ test_translation_stops_if_stop_codon_in_middle_of_three_codon_sequence(void)
    protein_t expected = {
       .valid = true,
       .count = 1,
-      .protein = { Tryptophan },
+      .amino_acids = { Tryptophan },
    };
    protein_t actual = protein("UGGUAGUGG");
    assert_protein_match(expected, actual);
@@ -327,7 +327,7 @@ test_translation_stops_if_stop_codon_in_middle_of_six_codon_sequence(void)
    protein_t expected = {
       .valid = true,
       .count = 3,
-      .protein = { Tryptophan, Cysteine, Tyrosine },
+      .amino_acids = { Tryptophan, Cysteine, Tyrosine },
    };
    protein_t actual = protein("UGGUGUUAUUAAUGGUUU");
    assert_protein_match(expected, actual);
@@ -340,7 +340,7 @@ test_sequence_of_two_non_stop_codons_does_not_translate_to_a_stop_codon(void)
    protein_t expected = {
       .valid = true,
       .count = 2,
-      .protein = { Methionine, Methionine },
+      .amino_acids = { Methionine, Methionine },
    };
    protein_t actual = protein("AUGAUG");
    assert_protein_match(expected, actual);
@@ -383,7 +383,7 @@ test_incomplete_rna_sequence_can_translate_if_valid_until_a_stop_codon(void)
    protein_t expected = {
       .valid = true,
       .count = 2,
-      .protein = { Phenylalanine, Phenylalanine },
+      .amino_acids = { Phenylalanine, Phenylalanine },
    };
    protein_t actual = protein("UUCUUCUAAUGGU");
    assert_protein_match(expected, actual);

--- a/exercises/practice/protein-translation/test_protein_translation.c
+++ b/exercises/practice/protein-translation/test_protein_translation.c
@@ -10,383 +10,383 @@ void tearDown(void)
 {
 }
 
-static void assert_proteins_match(proteins_t expected, proteins_t actual)
+static void assert_protein_match(protein_t expected, protein_t actual)
 {
    TEST_ASSERT_EQUAL_CHAR(expected.valid, actual.valid);
    if (expected.valid) {
       TEST_ASSERT_EQUAL_size_t(expected.count, actual.count);
       if (expected.count > 0) {
-         TEST_ASSERT_EQUAL_INT_ARRAY(expected.proteins, actual.proteins,
+         TEST_ASSERT_EQUAL_INT_ARRAY(expected.protein, actual.protein,
                                      expected.count);
       }
    }
 }
 
-static void test_empty_rna_sequence_results_in_no_proteins(void)
+static void test_empty_rna_sequence_results_in_no_protein(void)
 {
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 0,
    };
-   proteins_t actual = proteins("");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("");
+   assert_protein_match(expected, actual);
 }
 
 static void test_methionine_rna_sequence(void)
 {
    TEST_IGNORE();   // delete this line to run test
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Methionine },
+      .protein = { Methionine },
    };
-   proteins_t actual = proteins("AUG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("AUG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_phenylalanine_rna_sequence_1(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Phenylalanine },
+      .protein = { Phenylalanine },
    };
-   proteins_t actual = proteins("UUU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUU");
+   assert_protein_match(expected, actual);
 }
 
 static void test_phenylalanine_rna_sequence_2(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Phenylalanine },
+      .protein = { Phenylalanine },
    };
-   proteins_t actual = proteins("UUC");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUC");
+   assert_protein_match(expected, actual);
 }
 
 static void test_leucine_rna_sequence_1(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Leucine },
+      .protein = { Leucine },
    };
-   proteins_t actual = proteins("UUA");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUA");
+   assert_protein_match(expected, actual);
 }
 
 static void test_leucine_rna_sequence_2(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Leucine },
+      .protein = { Leucine },
    };
-   proteins_t actual = proteins("UUG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_serine_rna_sequence_1(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Serine },
+      .protein = { Serine },
    };
-   proteins_t actual = proteins("UCU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UCU");
+   assert_protein_match(expected, actual);
 }
 
 static void test_serine_rna_sequence_2(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Serine },
+      .protein = { Serine },
    };
-   proteins_t actual = proteins("UCC");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UCC");
+   assert_protein_match(expected, actual);
 }
 
 static void test_serine_rna_sequence_3(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Serine },
+      .protein = { Serine },
    };
-   proteins_t actual = proteins("UCA");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UCA");
+   assert_protein_match(expected, actual);
 }
 
 static void test_serine_rna_sequence_4(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Serine },
+      .protein = { Serine },
    };
-   proteins_t actual = proteins("UCG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UCG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_tyrosine_rna_sequence_1(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Tyrosine },
+      .protein = { Tyrosine },
    };
-   proteins_t actual = proteins("UAU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UAU");
+   assert_protein_match(expected, actual);
 }
 
 static void test_tyrosine_rna_sequence_2(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Tyrosine },
+      .protein = { Tyrosine },
    };
-   proteins_t actual = proteins("UAC");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UAC");
+   assert_protein_match(expected, actual);
 }
 
 static void test_cysteine_rna_sequence_1(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Cysteine },
+      .protein = { Cysteine },
    };
-   proteins_t actual = proteins("UGU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGU");
+   assert_protein_match(expected, actual);
 }
 
 static void test_cysteine_rna_sequence_2(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Cysteine },
+      .protein = { Cysteine },
    };
-   proteins_t actual = proteins("UGC");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGC");
+   assert_protein_match(expected, actual);
 }
 
 static void test_tryptophan_rna_sequence(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Tryptophan },
+      .protein = { Tryptophan },
    };
-   proteins_t actual = proteins("UGG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_stop_codon_rna_sequence_1(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 0,
    };
-   proteins_t actual = proteins("UAA");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UAA");
+   assert_protein_match(expected, actual);
 }
 
 static void test_stop_codon_rna_sequence_2(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 0,
    };
-   proteins_t actual = proteins("UAG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UAG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_stop_codon_rna_sequence_3(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 0,
    };
-   proteins_t actual = proteins("UGA");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGA");
+   assert_protein_match(expected, actual);
 }
 
-static void test_sequence_of_two_protein_codons_translates_into_proteins(void)
+static void test_sequence_of_two_protein_codons_translates_into_protein(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 2,
-      .proteins = { Phenylalanine, Phenylalanine },
+      .protein = { Phenylalanine, Phenylalanine },
    };
-   proteins_t actual = proteins("UUUUUU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUUUUU");
+   assert_protein_match(expected, actual);
 }
 
 static void
-test_sequence_of_two_different_protein_codons_translates_into_proteins(void)
+test_sequence_of_two_different_protein_codons_translates_into_protein(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 2,
-      .proteins = { Leucine, Leucine },
+      .protein = { Leucine, Leucine },
    };
-   proteins_t actual = proteins("UUAUUG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUAUUG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_translate_rna_strand_into_correct_protein_list(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 3,
-      .proteins = { Methionine, Phenylalanine, Tryptophan },
+      .protein = { Methionine, Phenylalanine, Tryptophan },
    };
-   proteins_t actual = proteins("AUGUUUUGG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("AUGUUUUGG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_translation_stops_if_stop_codon_at_beginning_of_sequence(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 0,
    };
-   proteins_t actual = proteins("UAGUGG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UAGUGG");
+   assert_protein_match(expected, actual);
 }
 
 static void
 test_translation_stops_if_stop_codon_at_end_of_two_codon_sequence(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Tryptophan },
+      .protein = { Tryptophan },
    };
-   proteins_t actual = proteins("UGGUAG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGGUAG");
+   assert_protein_match(expected, actual);
 }
 
 static void
 test_translation_stops_if_stop_codon_at_end_of_three_codon_sequence(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 2,
-      .proteins = { Methionine, Phenylalanine },
+      .protein = { Methionine, Phenylalanine },
    };
-   proteins_t actual = proteins("AUGUUUUAA");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("AUGUUUUAA");
+   assert_protein_match(expected, actual);
 }
 
 static void
 test_translation_stops_if_stop_codon_in_middle_of_three_codon_sequence(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 1,
-      .proteins = { Tryptophan },
+      .protein = { Tryptophan },
    };
-   proteins_t actual = proteins("UGGUAGUGG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGGUAGUGG");
+   assert_protein_match(expected, actual);
 }
 
 static void
 test_translation_stops_if_stop_codon_in_middle_of_six_codon_sequence(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 3,
-      .proteins = { Tryptophan, Cysteine, Tyrosine },
+      .protein = { Tryptophan, Cysteine, Tyrosine },
    };
-   proteins_t actual = proteins("UGGUGUUAUUAAUGGUUU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UGGUGUUAUUAAUGGUUU");
+   assert_protein_match(expected, actual);
 }
 
 static void
 test_sequence_of_two_non_stop_codons_does_not_translate_to_a_stop_codon(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 2,
-      .proteins = { Methionine, Methionine },
+      .protein = { Methionine, Methionine },
    };
-   proteins_t actual = proteins("AUGAUG");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("AUGAUG");
+   assert_protein_match(expected, actual);
 }
 
 static void test_non_existing_codon_cant_translate(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = false,
    };
-   proteins_t actual = proteins("AAA");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("AAA");
+   assert_protein_match(expected, actual);
 }
 
 static void test_unknown_amino_acids_not_part_of_a_codon_cant_translate(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = false,
    };
-   proteins_t actual = proteins("XYZ");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("XYZ");
+   assert_protein_match(expected, actual);
 }
 
 static void test_invalid_codon_cant_translate(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = false,
    };
-   proteins_t actual = proteins("AUGU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("AUGU");
+   assert_protein_match(expected, actual);
 }
 
 static void
 test_incomplete_rna_sequence_can_translate_if_valid_until_a_stop_codon(void)
 {
    TEST_IGNORE();
-   proteins_t expected = {
+   protein_t expected = {
       .valid = true,
       .count = 2,
-      .proteins = { Phenylalanine, Phenylalanine },
+      .protein = { Phenylalanine, Phenylalanine },
    };
-   proteins_t actual = proteins("UUCUUCUAAUGGU");
-   assert_proteins_match(expected, actual);
+   protein_t actual = protein("UUCUUCUAAUGGU");
+   assert_protein_match(expected, actual);
 }
 
 int main(void)
@@ -394,7 +394,7 @@ int main(void)
    UNITY_BEGIN();
 
    // clang-format off
-   RUN_TEST(test_empty_rna_sequence_results_in_no_proteins);
+   RUN_TEST(test_empty_rna_sequence_results_in_no_protein);
    RUN_TEST(test_methionine_rna_sequence);
    RUN_TEST(test_phenylalanine_rna_sequence_1);
    RUN_TEST(test_phenylalanine_rna_sequence_2);
@@ -412,8 +412,8 @@ int main(void)
    RUN_TEST(test_stop_codon_rna_sequence_1);
    RUN_TEST(test_stop_codon_rna_sequence_2);
    RUN_TEST(test_stop_codon_rna_sequence_3);
-   RUN_TEST(test_sequence_of_two_protein_codons_translates_into_proteins);
-   RUN_TEST(test_sequence_of_two_different_protein_codons_translates_into_proteins);
+   RUN_TEST(test_sequence_of_two_protein_codons_translates_into_protein);
+   RUN_TEST(test_sequence_of_two_different_protein_codons_translates_into_protein);
    RUN_TEST(test_translate_rna_strand_into_correct_protein_list);
    RUN_TEST(test_translation_stops_if_stop_codon_at_beginning_of_sequence);
    RUN_TEST(test_translation_stops_if_stop_codon_at_end_of_two_codon_sequence);


### PR DESCRIPTION
According to how the exercise's stub files and test files are currently written, one could assume that from a single RNA strand multiple proteins are decoded. In the example files, stub files and test file I made a few minor changes to the names of types, variables, etc. to more accurately reflect biological terminology, e.g., one 3-letter codon corresponds to one amino acid (Methionine, Phenylalanine, etc.), and one RNA sequence corresponds to one protein, which is made out of several amino acids. Feedback on this PR will be greatly appreciated.