### PR TITLE
Disable lychee-action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,14 +36,3 @@ jobs:
 
       - name: Check include guards
         run: ./bin/check-include-guards ./exercises/concept ./exercises/practice
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c
-        id: lychee
-        with:
-          args: --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36" --no-progress **/*.md **/*.html
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Fail if there were link errors
-        run: exit ${{ steps.lychee.outputs.exit_code }}


### PR DESCRIPTION
The lychee checks have been failing often for gnu.org and now they seem to fail 100% for GitHub links. I tried updating the lychee action with the same result and found [an issue](https://github.com/lycheeverse/lychee/issues/733) that seems to describe a similar issue that is blamed on a dependency of lychee that can't be easily fixed.

It seems like this check has gotten to be more trouble than it's worth. What does everyone think about disabling it? @wolf99 @siebenschlaefer 