### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/exercises/practice/beer-song/.meta/example.c
+++ b/exercises/practice/beer-song/.meta/example.c
@@ -2,29 +2,33 @@
 #include <stdint.h>
 #include <stdio.h>
 
+static const size_t MAX_LINE_LENGTH = 1024;
+
 static uint16_t get_verse(uint8_t bottles, char **verse)
 {
    uint16_t lines_written = 0;
 
    if (bottles == 0) {
-      sprintf(*verse,
-              "No more bottles of beer on the wall, no more bottles of beer.");
-      sprintf(
-          *++verse,
+      snprintf(*verse, MAX_LINE_LENGTH,
+               "No more bottles of beer on the wall, no more bottles of beer.");
+      snprintf(
+          *++verse, MAX_LINE_LENGTH,
           "Go to the store and buy some more, 99 bottles of beer on the wall.");
       lines_written = 2;
    } else if (bottles == 1) {
-      sprintf(*verse, "%u bottle of beer on the wall, %u bottle of beer.",
-              bottles, bottles);
-      sprintf(
-          *++verse,
+      snprintf(*verse, MAX_LINE_LENGTH,
+               "%u bottle of beer on the wall, %u bottle of beer.", bottles,
+               bottles);
+      snprintf(
+          *++verse, MAX_LINE_LENGTH,
           "Take it down and pass it around, no more bottles of beer on the wall.");
       lines_written = 3;
    } else {
-      sprintf(*verse, "%u bottles of beer on the wall, %u bottles of beer.",
-              bottles, bottles);
-      sprintf(
-          *++verse,
+      snprintf(*verse, MAX_LINE_LENGTH,
+               "%u bottles of beer on the wall, %u bottles of beer.", bottles,
+               bottles);
+      snprintf(
+          *++verse, MAX_LINE_LENGTH,
           "Take one down and pass it around, %u bottle%sof beer on the wall.",
           bottles - 1, bottles - 1 == 1 ? " " : "s ");
       lines_written = 3;

--- a/exercises/practice/clock/.meta/example.c
+++ b/exercises/practice/clock/.meta/example.c
@@ -26,7 +26,7 @@ clock_t clock_create(int hour, int minute)
 {
    clock_t clock = { { 0 } };
    normalize_clock(&hour, &minute);
-   sprintf(clock.text, CLOCK_FORMAT, hour, minute);
+   snprintf(clock.text, MAX_STR_LEN, CLOCK_FORMAT, hour, minute);
    return clock;
 }
 

--- a/exercises/practice/nucleotide-count/.meta/example.c
+++ b/exercises/practice/nucleotide-count/.meta/example.c
@@ -12,7 +12,8 @@ char *count(const char *dna_strand)
    size_t nucleotide_c_count = 0;
    size_t nucleotide_g_count = 0;
    size_t nucleotide_t_count = 0;
-   char *count_results = calloc(1, 50);
+   static const int max_length = 50;
+   char *count_results = calloc(1, max_length);
 
    for (index = 0; (index < strlen(dna_strand)) && (invalid_char == false);
         index++) {
@@ -36,8 +37,9 @@ char *count(const char *dna_strand)
    }
 
    if (!invalid_char) {
-      sprintf(count_results, "A:%zu C:%zu G:%zu T:%zu", nucleotide_a_count,
-              nucleotide_c_count, nucleotide_g_count, nucleotide_t_count);
+      snprintf(count_results, max_length, "A:%zu C:%zu G:%zu T:%zu",
+               nucleotide_a_count, nucleotide_c_count, nucleotide_g_count,
+               nucleotide_t_count);
    }
    return count_results;
 }

--- a/exercises/practice/raindrops/.meta/example.c
+++ b/exercises/practice/raindrops/.meta/example.c
@@ -16,7 +16,7 @@ void convert(char result[], int drops)
    }
    if (strlen(result) == 0) {
       char drops_string[12] = "\0";
-      sprintf(drops_string, "%d", drops);
+      snprintf(drops_string, sizeof(drops_string), "%d", drops);
       strcat(result, drops_string);
    }
 }

--- a/exercises/practice/run-length-encoding/.meta/example.c
+++ b/exercises/practice/run-length-encoding/.meta/example.c
@@ -31,7 +31,7 @@ static size_t enc_helper(char *encoded, const char *text,
          const size_t cdigits = count_digits(count);
          enc_len += cdigits;
          if (mode == WRITE) {
-            sprintf(encoded, "%zu", count);
+            snprintf(encoded, cdigits + 1, "%zu", count);
             encoded += cdigits;
          }
       }

--- a/exercises/practice/series/.meta/example.c
+++ b/exercises/practice/series/.meta/example.c
@@ -16,8 +16,8 @@ slices_t slices(char *input_text, unsigned int substring_length)
       for (int index = 0; index < substring_count; index++) {
          results.substring[index] =
              malloc(sizeof(char) * (substring_length + 1));
-         sprintf(results.substring[index], "%.*s", substring_length,
-                 &input_text[index]);
+         snprintf(results.substring[index], MAX_SERIES_RESULTS, "%.*s",
+                  substring_length, &input_text[index]);
       }
    }
    return results;


### PR DESCRIPTION
`sprintf` has been deprecated on macOS and a warning is issued when using it. `-Werror` turns the warning into an error, consequently tests don't pass on macOS. This fixes this by using `snprintf` instead.