### PR TITLE
Add macos-15 CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
-
     strategy:
       matrix:
+        os: [ubuntu-24.04, macos-15]
         compiler: [gcc, clang]
+        exclude:
+          - os: macos-15
+            compiler: gcc
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
gcc on arm64 macOS does not support sanitizers yet, so we only build with Apple Clang there.