### PR TITLE
Remove "submitting incomplete solutions" from help doc

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -3,10 +3,6 @@
 Make sure you have read the [C track-specific documentation][c-track] on the Exercism site.
 This covers the basic information on setting up the development environment expected by the exercises.
 
-## Submitting Incomplete Solutions
-
-If you are struggling with a particular exercise, it is possible to submit an incomplete solution so you can see how others have completed the exercise.
-
 ## Resources
 
 To get help if having trouble, you can use the following resources:


### PR DESCRIPTION
Including this in the `exercises/shared/.docs/help.md` file also adds it to the help text in the online editor (see screenshot in [this discord thread](https://discord.com/channels/854117591135027261/1414640905838792745/1414640905838792745)). Students cannot submit incomplete solutions from the online editor, so this advice is wrong.

For students working locally, the HELP.md text that gets generated for `exercism download` already includes text about submitting incomplete solutions.
* how HELP.md [gets generated](https://github.com/exercism/website/blob/d71ef0744c90fd43b4d167b173f10d9c9ca68fb9/app/commands/solution/generate_help_file.rb#L31)
* the [submit text](https://github.com/exercism/website/blob/d71ef0744c90fd43b4d167b173f10d9c9ca68fb9/config/locales/exercises/en.yml#L9)
* a [generated HELP.md file](https://github.com/glennj/exercism.io/blob/main/c/hamming/HELP.md) showing both the exercism-generated text plus the C-track-specific text.
