### PR TITLE
Duplicated codes in Raindrops <Dig Deeper>

### DIFF
--- a/exercises/practice/raindrops/.approaches/introduction.md
+++ b/exercises/practice/raindrops/.approaches/introduction.md
@@ -75,11 +75,6 @@ void convert(char result[], int drops);
 #include <stdio.h>
 #include <string.h>
 
-#include "raindrops.h"
-
-#include <stdio.h>
-#include <string.h>
-
 void convert(char result[], int drops)
 {
    sprintf(result, "%s%s%s", drops % 3 == 0 ? "Pling" : "",


### PR DESCRIPTION
Remove duplicated #include codes in example codes, likely mistakes in pasting.