### PR TITLE
Changed wrong/confusing prime factors instructions

### DIFF
--- a/exercises/practice/prime-factors/.docs/instructions.md
+++ b/exercises/practice/prime-factors/.docs/instructions.md
@@ -17,8 +17,6 @@ What are the prime factors of 60?
     So let's move on to our next divisor, 3.
 - 3 goes cleanly into 15, leaving 5.
   - 3 does not go cleanly into 5.
-    The next possible factor is 4.
-  - 4 does not go cleanly into 5.
     The next possible factor is 5.
 - 5 does go cleanly into 5.
 - We're left only with 1, so now, we're done.


### PR DESCRIPTION
Issue: The current instructions consider 4 a possible prime factor, despite it not being a prime number.

Fix: Remove lines mentioning 4 as a possible factor.