### PR TITLE
Add missing function declarations to resistor_color.h

### DIFF
--- a/exercises/practice/resistor-color/resistor_color.h
+++ b/exercises/practice/resistor-color/resistor_color.h
@@ -2,7 +2,19 @@
 #define RESISTOR_COLOR_H
 
 typedef enum {
-
+    BLACK = 0,
+    BROWN,
+    RED,
+    ORANGE,
+    YELLOW,
+    GREEN,
+    BLUE,
+    VIOLET,
+    GREY,
+    WHITE
 } resistor_band_t;
+
+int color_code(resistor_band_t color);
+const char **colors(void);
 
 #endif


### PR DESCRIPTION
The header file currently contains an empty enum definition,
which may be confusing for contributors working locally.

Fixes #1095

This change adds:
- Enum values for resistor colors
- Function declarations for color_code() and colors()

This improves clarity and aligns the header with the expected API.