### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/circular-buffer/.docs/instructions.append.md
+++ b/exercises/practice/circular-buffer/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# Set `errno` to a special value
+# Instructions append
+
+## Set `errno` to a special value
+
 If the buffer is empty during a read attempt, an error is raised to alert the client.
 
 These error values can be found in the [`errno.h`][errno.h] header file.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Use UTC
 
 To solve this problem, you'll need to convert a `time_t` value into a `struct tm` value.

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The functions in this exercise accept an array containing one or more numbers, each representing one 'game score'.
 
 The player's game scores can be read from

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 - Note that the tests for this exercise expect the output words to be proper C strings. That is, they should be NUL terminated. See https://en.wikipedia.org/wiki/C_string_handling


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.